### PR TITLE
Add Common Dunder Variables and Builtins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,7 @@ add_executable(pycompile-tests
         test/execution/test_tuple_execution.cpp
         test/execution/test_dict_execution.cpp
         test/execution/test_iter_execution.cpp
+        test/execution/test_builtin_execution.cpp
         test/execution/pyir_run_module.cpp
 )
 target_link_libraries(pycompile-tests PRIVATE ${PYCOMPILE_LIBS} stdpyir Catch2::Catch2WithMain)

--- a/examples/builtins.py
+++ b/examples/builtins.py
@@ -1,0 +1,13 @@
+print("Range:", range(5))
+
+print("Enumerate:", enumerate(['zero', 'one', 'two']))
+
+print("Zip:", zip([1, 2, 3], ['a', 'b', 'c']))
+
+print("Type List:", type([]))
+
+print("Instance:", isinstance([], list))
+
+print("Name:", __name__)
+
+print("File:", __file__)

--- a/include/lowering/memory_lowering.h
+++ b/include/lowering/memory_lowering.h
@@ -10,6 +10,26 @@
 
 
 /**
+ * Lowers pyir.init_module to a call to the runtime function pyir_initModule.
+ *
+ * The file and name strings are stored as global constants and passed as const char* pointers.
+ * The runtime pre-populates the module scope with dunder variables such as __name__ and __file__.
+ *
+ * pyir.init_module "<embedded>", "__main__"
+ *     %file_ptr = llvm.mlir.addressof @__pyir_str___pymodule_file__
+ *     %name_ptr = llvm.mlir.addressof @__pyir_str___pymodule_name__
+ *                 llvm.call @pyir_initModule(%file_ptr, %name_ptr)
+ */
+struct InitModuleLowering : PyIROpConversion {
+    InitModuleLowering(const mlir::LLVMTypeConverter& tc, mlir::MLIRContext* ctx) :
+        PyIROpConversion(pyir::InitModule::getOperationName(), tc, ctx) {}
+
+    mlir::LogicalResult matchAndRewrite(mlir::Operation* op, mlir::ArrayRef<mlir::Value>,
+                                        mlir::ConversionPatternRewriter& rewriter) const override;
+};
+
+
+/**
  * Lowers pyir.load_fast to a call to the runtime function pyir_loadFast.
  *
  * The name string is stored as a constant and passed as a const char* pointer. The runtime resolves the name

--- a/include/pyir/pyir.td
+++ b/include/pyir/pyir.td
@@ -31,6 +31,13 @@ def PyIR_NoneAttr : AttrDef<PyIR_Dialect, "None"> {
 class PyIR_Op<string mnemonic, list<Trait> traits = []> : Op<PyIR_Dialect, mnemonic, traits>;
 
 
+def PyIR_InitModule : PyIR_Op<"init_module"> {
+    let summary = "Initialize module-level metadata";
+    let arguments = (ins StrAttr:$file, StrAttr:$name);
+    let assemblyFormat = "$file `,` $name attr-dict";
+}
+
+
 def PyIR_Resume : PyIR_Op<"resume"> {
     let summary = "Resume execution of a generator or start a module";
     let arguments = (ins SI64Attr:$arg);

--- a/include/pyruntime/builtin_runtime.h
+++ b/include/pyruntime/builtin_runtime.h
@@ -39,6 +39,16 @@ PyObj* pyir_builtinDict(PyObj** args, int64_t argc);
 PyObj* pyir_builtinIter(PyObj** args, int64_t argc);
 
 PyObj* pyir_builtinNext(PyObj** args, int64_t argc);
+
+PyObj* pyir_builtinEnumerate(PyObj** args, int64_t argc);
+
+PyObj* pyir_builtinIsInstance(PyObj** args, int64_t argc);
+
+PyObj* pyir_builtinRange(PyObj** args, int64_t argc);
+
+PyObj* pyir_builtinType(PyObj** args, int64_t argc);
+
+PyObj* pyir_builtinZip(PyObj** args, int64_t argc);
 }
 
 #endif // PYCOMPILE_BUILTIN_RUNTIME_H

--- a/include/pyruntime/builtin_runtime.h
+++ b/include/pyruntime/builtin_runtime.h
@@ -9,12 +9,12 @@
 extern "C" {
 
 struct PyObj;
-struct PyNone;
-struct PyInt;
-struct PyBool;
-struct PyStr;
-struct PyFloat;
-struct PyList;
+
+PyObj* pyir_builtinVarName();
+
+PyObj* pyir_builtinVarFile();
+
+void pyir_initModule(const char* file, const char* name);
 
 PyObj* pyir_builtinPrint(PyObj** args, int64_t argc);
 

--- a/include/pyruntime/objects/py_dict.h
+++ b/include/pyruntime/objects/py_dict.h
@@ -65,6 +65,10 @@ struct PyDictIter : PyIter {
 
     static PyObj* next(PyObj* self, PyObj**, int64_t argc);
 
+    [[nodiscard]] std::string toString() const override { return "<dict_iterator>"; }
+
+    [[nodiscard]] std::string typeName() const override { return "dict_iterator"; }
+
     std::partial_ordering operator<=>(const PyObj& other) const noexcept override;
 
 private:

--- a/include/pyruntime/objects/py_iter.h
+++ b/include/pyruntime/objects/py_iter.h
@@ -16,10 +16,6 @@ struct PyNone;
 struct PyIter : PyObj {
     [[nodiscard]] size_t hash() const override { throw std::runtime_error("Unhashable type " + typeName()); }
 
-    [[nodiscard]] std::string toString() const override { return "<iterator>"; }
-
-    [[nodiscard]] std::string typeName() const override { return "iter"; }
-
     [[nodiscard]] bool isTruthy() const override { return true; }
 
     std::partial_ordering operator<=>(const PyObj& other) const noexcept override = 0;

--- a/include/pyruntime/objects/py_list.h
+++ b/include/pyruntime/objects/py_list.h
@@ -59,6 +59,10 @@ struct PyListIter : PyIter {
 
     static PyObj* next(PyObj* self, PyObj**, int64_t argc);
 
+    [[nodiscard]] std::string toString() const override { return "<list_iterator>"; }
+
+    [[nodiscard]] std::string typeName() const override { return "list_iterator"; }
+
     std::partial_ordering operator<=>(const PyObj& other) const noexcept override;
 
 private:

--- a/include/pyruntime/objects/py_set.h
+++ b/include/pyruntime/objects/py_set.h
@@ -55,6 +55,10 @@ struct PySetIter : PyIter {
 
     static PyObj* next(PyObj* self, PyObj**, int64_t argc);
 
+    [[nodiscard]] std::string toString() const override { return "<set_iterator>"; }
+
+    [[nodiscard]] std::string typeName() const override { return "set_iterator"; }
+
     std::partial_ordering operator<=>(const PyObj& other) const noexcept override;
 
 private:

--- a/include/pyruntime/objects/py_str.h
+++ b/include/pyruntime/objects/py_str.h
@@ -44,6 +44,10 @@ struct PyStrIter : PyIter {
 
     static PyObj* next(PyObj* self, PyObj**, int64_t argc);
 
+    [[nodiscard]] std::string toString() const override { return "<str_iterator>"; }
+
+    [[nodiscard]] std::string typeName() const override { return "str_iterator"; }
+
     std::partial_ordering operator<=>(const PyObj& other) const noexcept override;
 
 private:

--- a/include/pyruntime/objects/py_tuple.h
+++ b/include/pyruntime/objects/py_tuple.h
@@ -45,9 +45,13 @@ private:
 
 
 struct PyTupleIter : PyIter {
-    explicit PyTupleIter(PyTupleData tuple) : tuple(std::move(tuple)) {it = this->tuple.begin();}
+    explicit PyTupleIter(PyTupleData tuple) : tuple(std::move(tuple)) { it = this->tuple.begin(); }
 
     static PyObj* next(PyObj* self, PyObj**, int64_t argc);
+
+    [[nodiscard]] std::string toString() const override { return "<tuple_iterator>"; }
+
+    [[nodiscard]] std::string typeName() const override { return "tuple_iterator"; }
 
     std::partial_ordering operator<=>(const PyObj& other) const noexcept override;
 

--- a/include/pyruntime/runtime_state.h
+++ b/include/pyruntime/runtime_state.h
@@ -16,8 +16,10 @@ const std::unordered_map<std::string, PyFunctionData> builtinFuncs = {
         {"list", pyir_builtinList},   {"set", pyir_builtinSet},   {"tuple", pyir_builtinTuple},
         {"dict", pyir_builtinDict},   {"iter", pyir_builtinIter}, {"next", pyir_builtinNext}};
 
-const std::unordered_map<std::string, PyFunctionData> builtinVars = {{"print", pyir_builtinPrint},
-                                                                     {"len", pyir_builtinLen}};
+
+using PyBuiltinVarFunction = PyObj* (*) ();
+const std::unordered_map<std::string, PyBuiltinVarFunction> builtinVars = {{"__file__", pyir_builtinVarFile},
+                                                                           {"__name__", pyir_builtinVarName}};
 
 inline std::unordered_map<std::string, PyObj*> moduleScope;
 inline std::vector<std::unordered_map<std::string, PyObj*>> scopeStack;

--- a/include/pyruntime/runtime_state.h
+++ b/include/pyruntime/runtime_state.h
@@ -23,7 +23,7 @@ const std::unordered_map<std::string, PyFunctionData> builtinFuncs = {{"print", 
                                                                       {"iter", pyir_builtinIter},
                                                                       {"next", pyir_builtinNext},
                                                                       {"enumerate", pyir_builtinEnumerate},
-                                                                      {"isInstance", pyir_builtinIsInstance},
+                                                                      {"isinstance", pyir_builtinIsInstance},
                                                                       {"range", pyir_builtinRange},
                                                                       {"type", pyir_builtinType},
                                                                       {"zip", pyir_builtinZip}};

--- a/include/pyruntime/runtime_state.h
+++ b/include/pyruntime/runtime_state.h
@@ -10,11 +10,14 @@
 #include "builtin_runtime.h"
 #include "objects/py_function.h"
 
-const std::unordered_map<std::string, PyFunctionData> builtins = {
+const std::unordered_map<std::string, PyFunctionData> builtinFuncs = {
         {"print", pyir_builtinPrint}, {"len", pyir_builtinLen},   {"int", pyir_builtinInt},
         {"float", pyir_builtinFloat}, {"str", pyir_builtinStr},   {"bool", pyir_builtinBool},
         {"list", pyir_builtinList},   {"set", pyir_builtinSet},   {"tuple", pyir_builtinTuple},
         {"dict", pyir_builtinDict},   {"iter", pyir_builtinIter}, {"next", pyir_builtinNext}};
+
+const std::unordered_map<std::string, PyFunctionData> builtinVars = {{"print", pyir_builtinPrint},
+                                                                     {"len", pyir_builtinLen}};
 
 inline std::unordered_map<std::string, PyObj*> moduleScope;
 inline std::vector<std::unordered_map<std::string, PyObj*>> scopeStack;

--- a/include/pyruntime/runtime_state.h
+++ b/include/pyruntime/runtime_state.h
@@ -10,11 +10,23 @@
 #include "builtin_runtime.h"
 #include "objects/py_function.h"
 
-const std::unordered_map<std::string, PyFunctionData> builtinFuncs = {
-        {"print", pyir_builtinPrint}, {"len", pyir_builtinLen},   {"int", pyir_builtinInt},
-        {"float", pyir_builtinFloat}, {"str", pyir_builtinStr},   {"bool", pyir_builtinBool},
-        {"list", pyir_builtinList},   {"set", pyir_builtinSet},   {"tuple", pyir_builtinTuple},
-        {"dict", pyir_builtinDict},   {"iter", pyir_builtinIter}, {"next", pyir_builtinNext}};
+const std::unordered_map<std::string, PyFunctionData> builtinFuncs = {{"print", pyir_builtinPrint},
+                                                                      {"len", pyir_builtinLen},
+                                                                      {"int", pyir_builtinInt},
+                                                                      {"float", pyir_builtinFloat},
+                                                                      {"str", pyir_builtinStr},
+                                                                      {"bool", pyir_builtinBool},
+                                                                      {"list", pyir_builtinList},
+                                                                      {"set", pyir_builtinSet},
+                                                                      {"tuple", pyir_builtinTuple},
+                                                                      {"dict", pyir_builtinDict},
+                                                                      {"iter", pyir_builtinIter},
+                                                                      {"next", pyir_builtinNext},
+                                                                      {"enumerate", pyir_builtinEnumerate},
+                                                                      {"isInstance", pyir_builtinIsInstance},
+                                                                      {"range", pyir_builtinRange},
+                                                                      {"type", pyir_builtinType},
+                                                                      {"zip", pyir_builtinZip}};
 
 
 using PyBuiltinVarFunction = PyObj* (*) ();

--- a/src/bytecode/bytecode.cpp
+++ b/src/bytecode/bytecode.cpp
@@ -118,7 +118,7 @@ std::vector<std::string> extractPyTupleStrings(PyObject* code, const char* attr)
 }
 
 // Forward declaration
-ByteCodeModule generatePythonByteCode(PyObject* code, const std::string& filename, int depth = 0);
+ByteCodeModule generatePythonByteCode(PyObject* code, const std::string& filename, bool isMain, int depth = 0);
 
 
 /**
@@ -254,7 +254,7 @@ ByteCodeInstruction decodeByteCodeInstruction(PyObject* pyobject, const std::str
         instr.argval = decodeFrozenSet(argval, filename, instr);
     } else if (PyCode_Check(argval)) {
         instr.argvalType = ArgvalType::Code;
-        instr.argval = std::make_shared<ByteCodeModule>(generatePythonByteCode(argval, filename, depth + 1));
+        instr.argval = std::make_shared<ByteCodeModule>(generatePythonByteCode(argval, filename, false, depth + 1));
     } else if (Py_IsNone(argval)) {
         instr.argvalType = ArgvalType::None;
         instr.argval = ArgvalNone{};
@@ -270,14 +270,15 @@ ByteCodeInstruction decodeByteCodeInstruction(PyObject* pyobject, const std::str
  * This function is recursive and will disassemble nested code objects (e.g. lambdas, comprehensions) up to a max depth.
  * @param code A Python code object containing the program to be translated.
  * @param filename The filename of the compiled module.
+ * @param isMain Whether the bytecode represents the program's main module
  * @param depth The current recursion depth for nested code objects (default is 0).
  * @return A ByteCodeModule struct containing the metadata and instructions of the code object.
  * @throws std::runtime_error if the max nested function depth is exceeded, or if there are errors during disassembly.
  */
-ByteCodeModule generatePythonByteCode(PyObject* code, const std::string& filename, const int depth) {
+ByteCodeModule generatePythonByteCode(PyObject* code, const std::string& filename, const bool isMain, const int depth) {
     ByteCodeModule result;
     result.filename = filename;
-    result.moduleName = std::filesystem::path(filename).stem();
+    result.moduleName = isMain ? "__main__" : std::filesystem::path(filename).stem();
 
     if (depth > NESTED_FUNCTION_DEPTH)
         throw std::runtime_error("Maximum nested function depth exceeded");
@@ -338,7 +339,7 @@ std::vector<ByteCodeModule> compilePython(const std::vector<std::string>& fileCo
             if (!code)
                 throw std::runtime_error(getPythonErrorTraceback());
 
-            bytecodeModules.push_back(generatePythonByteCode(code, fileNames[i]));
+            bytecodeModules.push_back(generatePythonByteCode(code, fileNames[i], i == 0));
             Py_DECREF(code); // Destroy object before scope ends
         } catch (const std::runtime_error& e) {
             throw std::runtime_error(std::filesystem::path(fileNames[i]).filename().string() + ": " + e.what());

--- a/src/conversion/pyir_codegen.cpp
+++ b/src/conversion/pyir_codegen.cpp
@@ -210,6 +210,10 @@ void buildMLIRModule(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const Byt
             builder.create<pyir::StoreFast>(preambleLoc, module.info.varnames[i], argVal);
         }
     }
+    // For modules, setup dunder variables and state
+    else
+        builder.create<pyir::InitModule>(preambleLoc, module.filename, module.moduleName);
+
 
     // Exception table handler targets also get blocks
     for (const ExceptionTableEntry& e : module.info.exceptionTable)

--- a/src/lowering/memory_lowering.cpp
+++ b/src/lowering/memory_lowering.cpp
@@ -6,6 +6,28 @@
 #include "pyir/pyir_attrs.h"
 
 
+mlir::LogicalResult InitModuleLowering::matchAndRewrite(mlir::Operation* op, mlir::ArrayRef<mlir::Value>,
+                                                        mlir::ConversionPatternRewriter& rewriter) const {
+    pyir::InitModule initModule = mlir::cast<pyir::InitModule>(op);
+    mlir::MLIRContext* ctx = op->getContext();
+    const mlir::ModuleOp module = getModule(op);
+    const mlir::Location loc = op->getLoc();
+
+    // declare: extern void pyir_initModule(const char* file, const char* name)
+    const mlir::LLVM::LLVMFunctionType fnType =
+            mlir::LLVM::LLVMFunctionType::get(mlir::LLVM::LLVMVoidType::get(ctx), {ptrType(ctx), ptrType(ctx)});
+    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_initModule", fnType);
+
+    const std::string globalFile = "__pyir_str_" + initModule.getFile().str();
+    const std::string globalName = "__pyir_str_" + initModule.getName().str();
+    const mlir::Value filePtr = getOrInsertStringConstant(rewriter, module, loc, globalFile, initModule.getFile());
+    const mlir::Value namePtr = getOrInsertStringConstant(rewriter, module, loc, globalName, initModule.getName());
+    rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{filePtr, namePtr});
+    rewriter.eraseOp(op);
+    return mlir::success();
+}
+
+
 mlir::LogicalResult LoadFastLowering::matchAndRewrite(mlir::Operation* op, mlir::ArrayRef<mlir::Value>,
                                                       mlir::ConversionPatternRewriter& rewriter) const {
     pyir::LoadFast loadFast = mlir::cast<pyir::LoadFast>(op);

--- a/src/lowering/pyir_lowering.cpp
+++ b/src/lowering/pyir_lowering.cpp
@@ -90,9 +90,9 @@ protected:
 
 void populatePyIRToLLVMPatterns(mlir::RewritePatternSet& patterns, mlir::LLVMTypeConverter& typeConverter) {
     mlir::MLIRContext* ctx = patterns.getContext();
-    patterns.add<IsTruthyLowering, ToBoolLowering, UnaryNegativeLowering, UnaryNotLowering, UnaryInvertLowering,
-                 BinaryOpLowering, CompareOpLowering, LoadFastLowering, StoreFastLowering, LoadNameLowering,
-                 StoreNameLowering, LoadConstLowering, PushNullLowering, CallLowering, PopTopLowering,
+    patterns.add<InitModuleLowering, IsTruthyLowering, ToBoolLowering, UnaryNegativeLowering, UnaryNotLowering,
+                 UnaryInvertLowering, BinaryOpLowering, CompareOpLowering, LoadFastLowering, StoreFastLowering,
+                 LoadNameLowering, StoreNameLowering, LoadConstLowering, PushNullLowering, CallLowering, PopTopLowering,
                  FormatSimpleLowering, BuildStringLowering, PushScopeLowering, PopScopeLowering, LoadArgLowering,
                  MakeFunctionLowering, ReturnValueLowering, BuildListLowering, ListExtendLowering, ListAppendLowering,
                  LoadAttrLowering, ContainsOpLowering, BuildSetLowering, SetUpdateLowering, SetAddLowering,

--- a/src/pyir/pyir.cpp
+++ b/src/pyir/pyir.cpp
@@ -12,10 +12,10 @@
 
 namespace pyir {
     void PyIRDialect::initialize() {
-        addOperations<ToBool, IsTruthy, BinaryOp, Call, LoadConst, LoadDeref, LoadFast, LoadName, StoreName, PopTop,
-                      PushNull, Resume, ReturnValue, StoreFast, StoreDeref, UnaryNot, UnaryNegative, UnaryInvert,
-                      CompareOp, FormatSimple, BuildString, MakeFunction, PushScope, PopScope, LoadArg, BuildList,
-                      ListExtend, ListAppend, LoadAttr, ContainsOp, BuildSet, SetUpdate, SetAdd, BuildMap,
+        addOperations<InitModule, ToBool, IsTruthy, BinaryOp, Call, LoadConst, LoadDeref, LoadFast, LoadName, StoreName,
+                      PopTop, PushNull, Resume, ReturnValue, StoreFast, StoreDeref, UnaryNot, UnaryNegative,
+                      UnaryInvert, CompareOp, FormatSimple, BuildString, MakeFunction, PushScope, PopScope, LoadArg,
+                      BuildList, ListExtend, ListAppend, LoadAttr, ContainsOp, BuildSet, SetUpdate, SetAdd, BuildMap,
                       StoreSubscr>();
 
         addTypes<ByteCodeObjectType>();

--- a/src/pyruntime/builtin_runtime.cpp
+++ b/src/pyruntime/builtin_runtime.cpp
@@ -5,6 +5,7 @@
 #include "pyruntime/builtin_runtime.h"
 
 #include <cmath>
+#include <format>
 #include <ranges>
 #include <stdexcept>
 
@@ -254,7 +255,11 @@ PyObj* pyir_builtinRange(PyObj** args, const int64_t argc) {
 }
 
 
-PyObj* pyir_builtinType(PyObj** args, const int64_t argc) { return new PyNone(); }
+PyObj* pyir_builtinType(PyObj** args, const int64_t argc) {
+    if (argc == 0)
+        throw std::runtime_error("type() takes at least one argument");
+    return new PyStr(std::format("<class '{}'>", args[0]->typeName()));
+}
 
 
 PyObj* pyir_builtinZip(PyObj** args, const int64_t argc) { return new PyNone(); }

--- a/src/pyruntime/builtin_runtime.cpp
+++ b/src/pyruntime/builtin_runtime.cpp
@@ -182,30 +182,7 @@ PyObj* pyir_builtinEnumerate(PyObj** args, const int64_t argc) {
     if (argc == 0)
         throw std::runtime_error("enumerate() takes one argument");
     std::vector<PyObj*> result;
-    if (const PyStr* str = dynamic_cast<PyStr*>(args[0]))
-        for (size_t i = 0; i < str->data().size(); i++) {
-            result.push_back(new PyTuple({new PyInt(static_cast<int64_t>(i)), new PyStr(str->data()[i])}));
-        }
-    if (const PyList* list = dynamic_cast<PyList*>(args[0]))
-        for (size_t i = 0; i < list->data().size(); i++) {
-            PyObj* elem = list->data()[i];
-            elem->incref();
-            result.push_back(new PyTuple({new PyInt(static_cast<int64_t>(i)), elem}));
-        }
-    if (const PyTuple* tuple = dynamic_cast<PyTuple*>(args[0]))
-        for (size_t i = 0; i < tuple->data().size(); i++) {
-            PyObj* elem = tuple->data()[i];
-            elem->incref();
-            result.push_back(new PyTuple({new PyInt(static_cast<int64_t>(i)), elem}));
-        }
-    if (const PySet* set = dynamic_cast<PySet*>(args[0])) {
-        size_t i = 0;
-        for (PyObj* elem : set->data()) {
-            elem->incref();
-            result.push_back(new PyTuple({new PyInt(static_cast<int64_t>(i)), elem}));
-            i++;
-        }
-    }
+    // Iterate over keys for dict
     if (PyDict* dict = dynamic_cast<PyDict*>(args[0])) {
         size_t i = 0;
         for (const auto& key : dict->data() | std::views::keys) {
@@ -213,6 +190,15 @@ PyObj* pyir_builtinEnumerate(PyObj** args, const int64_t argc) {
             result.push_back(new PyTuple({new PyInt(static_cast<int64_t>(i)), key}));
             i++;
         }
+    } else {
+        PyInt* length = args[0]->len();
+        for (int64_t i = 0; i < length->data(); i++) {
+            PyInt* idx = new PyInt(i);
+            PyObj* elem = args[0]->idx(idx);
+            elem->incref();
+            result.push_back(new PyTuple({idx, elem}));
+        }
+        length->decref();
     }
 
     return new PyList(result);
@@ -262,4 +248,59 @@ PyObj* pyir_builtinType(PyObj** args, const int64_t argc) {
 }
 
 
-PyObj* pyir_builtinZip(PyObj** args, const int64_t argc) { return new PyNone(); }
+PyObj* getShortestContainer(PyObj** args, const int64_t argc) {
+    if (argc < 1)
+        throw std::runtime_error("Expected at least one element to compare the lengths of");
+    int64_t minLength = INT64_MAX;
+    PyObj* shortest = nullptr;
+    for (int64_t i = 0; i < argc; i++) {
+        PyInt* length = args[i]->len();
+        if (length->data() < minLength) {
+            minLength = length->data();
+            shortest = args[i];
+        }
+        length->decref();
+    }
+
+    return shortest;
+}
+
+
+PyObj* pyir_builtinZip(PyObj** args, const int64_t argc) {
+    if (argc < 1)
+        throw std::runtime_error("zip() takes at least one argument");
+    const PyObj* shortest = getShortestContainer(args, argc);
+    const PyInt* shortestLen = shortest->len();
+    std::vector<std::vector<PyObj*>> zipped(shortestLen->data());
+    for (int64_t elemIdx = 0; elemIdx < shortestLen->data(); elemIdx++)
+        zipped[elemIdx] = std::vector<PyObj*>(argc);
+
+    for (int64_t containerIdx = 0; containerIdx < argc; containerIdx++) {
+        // Iterate over keys for dict
+        if (PyDict* dict = dynamic_cast<PyDict*>(args[containerIdx])) {
+            int64_t elemIdx = 0;
+            for (const auto& key : dict->data() | std::views::keys) {
+                if (elemIdx > shortestLen->data())
+                    break;
+
+                key->incref();
+                zipped[elemIdx][containerIdx] = key;
+                elemIdx++;
+            }
+        } else {
+            PyInt* length = args[containerIdx]->len();
+            for (int64_t elemIdx = 0; elemIdx < shortestLen->data(); elemIdx++) {
+                const PyInt* idx = new PyInt(elemIdx);
+                PyObj* elem = args[containerIdx]->idx(idx);
+                elem->incref();
+                zipped[elemIdx][containerIdx] = elem;
+            }
+            length->decref();
+        }
+    }
+
+    std::vector<PyObj*> result;
+    for (int64_t elemIdx = 0; elemIdx < shortestLen->data(); elemIdx++)
+        result.push_back(new PyTuple(zipped[elemIdx]));
+    return new PyList(result);
+}

--- a/src/pyruntime/builtin_runtime.cpp
+++ b/src/pyruntime/builtin_runtime.cpp
@@ -11,6 +11,7 @@
 #include "pyruntime/objects/py_bool.h"
 #include "pyruntime/objects/py_dict.h"
 #include "pyruntime/objects/py_float.h"
+#include "pyruntime/objects/py_function.h"
 #include "pyruntime/objects/py_int.h"
 #include "pyruntime/objects/py_iter.h"
 #include "pyruntime/objects/py_list.h"
@@ -178,7 +179,7 @@ PyObj* pyir_builtinNext(PyObj** args, const int64_t argc) {
 
 PyObj* pyir_builtinEnumerate(PyObj** args, const int64_t argc) {
     if (argc == 0)
-        throw std::runtime_error("enumerate() takes at least one argument");
+        throw std::runtime_error("enumerate() takes one argument");
     std::vector<PyObj*> result;
     if (const PyStr* str = dynamic_cast<PyStr*>(args[0]))
         for (size_t i = 0; i < str->data().size(); i++) {
@@ -217,7 +218,14 @@ PyObj* pyir_builtinEnumerate(PyObj** args, const int64_t argc) {
 }
 
 
-PyObj* pyir_builtinIsInstance(PyObj** args, const int64_t argc) { return new PyNone(); }
+PyObj* pyir_builtinIsInstance(PyObj** args, const int64_t argc) {
+    if (argc < 2)
+        throw std::runtime_error("enumerate() takes two arguments");
+    const PyObj* instance = args[0];
+    if (const PyFunction* type = dynamic_cast<PyFunction*>(args[1]))
+        return new PyBool(instance->typeName() == type->funcName());
+    throw std::runtime_error("isinstance() takes a tye as the second argument");
+}
 
 
 PyObj* pyir_builtinRange(PyObj** args, const int64_t argc) {

--- a/src/pyruntime/builtin_runtime.cpp
+++ b/src/pyruntime/builtin_runtime.cpp
@@ -176,16 +176,39 @@ PyObj* pyir_builtinNext(PyObj** args, const int64_t argc) {
 }
 
 
-PyObj* pyir_builtinEnumerate(PyObj** args, int64_t argc) {}
+PyObj* pyir_builtinEnumerate(PyObj** args, const int64_t argc) { return new PyNone(); }
 
 
-PyObj* pyir_builtinIsInstance(PyObj** args, int64_t argc) {}
+PyObj* pyir_builtinIsInstance(PyObj** args, const int64_t argc) { return new PyNone(); }
 
 
-PyObj* pyir_builtinRange(PyObj** args, int64_t argc) {}
+PyObj* pyir_builtinRange(PyObj** args, const int64_t argc) {
+    if (argc == 0)
+        throw std::runtime_error("range() takes at least one argument");
+    int64_t startIdx = 0;
+    int64_t endIdx = 0;
+    if (argc >= 1) {
+        if (const PyInt* endInteger = dynamic_cast<PyInt*>(args[argc == 1 ? 0 : 1]))
+            endIdx = endInteger->data();
+        else
+            throw std::runtime_error("range() expects integer arguments");
+    }
+    if (argc == 2) {
+        if (const PyInt* startInteger = dynamic_cast<PyInt*>(args[0]))
+            startIdx = startInteger->data();
+        else
+            throw std::runtime_error("range() expects integer arguments");
+    } else if (argc > 2)
+        throw std::runtime_error("range() takes at most two arguments");
+
+    std::vector<PyObj*> seq;
+    for (int64_t i = startIdx; i < endIdx; i++)
+        seq.push_back(new PyInt(i));
+    return new PyTuple(seq);
+}
 
 
-PyObj* pyir_builtinType(PyObj** args, int64_t argc) {}
+PyObj* pyir_builtinType(PyObj** args, const int64_t argc) { return new PyNone(); }
 
 
-PyObj* pyir_builtinZip(PyObj** args, int64_t argc) {}
+PyObj* pyir_builtinZip(PyObj** args, const int64_t argc) { return new PyNone(); }

--- a/src/pyruntime/builtin_runtime.cpp
+++ b/src/pyruntime/builtin_runtime.cpp
@@ -176,7 +176,45 @@ PyObj* pyir_builtinNext(PyObj** args, const int64_t argc) {
 }
 
 
-PyObj* pyir_builtinEnumerate(PyObj** args, const int64_t argc) { return new PyNone(); }
+PyObj* pyir_builtinEnumerate(PyObj** args, const int64_t argc) {
+    if (argc == 0)
+        throw std::runtime_error("enumerate() takes at least one argument");
+    std::vector<PyObj*> result;
+    if (const PyStr* str = dynamic_cast<PyStr*>(args[0]))
+        for (size_t i = 0; i < str->data().size(); i++) {
+            result.push_back(new PyTuple({new PyInt(static_cast<int64_t>(i)), new PyStr(str->data()[i])}));
+        }
+    if (const PyList* list = dynamic_cast<PyList*>(args[0]))
+        for (size_t i = 0; i < list->data().size(); i++) {
+            PyObj* elem = list->data()[i];
+            elem->incref();
+            result.push_back(new PyTuple({new PyInt(static_cast<int64_t>(i)), elem}));
+        }
+    if (const PyTuple* tuple = dynamic_cast<PyTuple*>(args[0]))
+        for (size_t i = 0; i < tuple->data().size(); i++) {
+            PyObj* elem = tuple->data()[i];
+            elem->incref();
+            result.push_back(new PyTuple({new PyInt(static_cast<int64_t>(i)), elem}));
+        }
+    if (const PySet* set = dynamic_cast<PySet*>(args[0])) {
+        size_t i = 0;
+        for (PyObj* elem : set->data()) {
+            elem->incref();
+            result.push_back(new PyTuple({new PyInt(static_cast<int64_t>(i)), elem}));
+            i++;
+        }
+    }
+    if (PyDict* dict = dynamic_cast<PyDict*>(args[0])) {
+        size_t i = 0;
+        for (const auto& key : dict->data() | std::views::keys) {
+            key->incref();
+            result.push_back(new PyTuple({new PyInt(static_cast<int64_t>(i)), key}));
+            i++;
+        }
+    }
+
+    return new PyList(result);
+}
 
 
 PyObj* pyir_builtinIsInstance(PyObj** args, const int64_t argc) { return new PyNone(); }

--- a/src/pyruntime/builtin_runtime.cpp
+++ b/src/pyruntime/builtin_runtime.cpp
@@ -174,3 +174,18 @@ PyObj* pyir_builtinNext(PyObj** args, const int64_t argc) {
 
     throw std::runtime_error("cannot convert to iter()");
 }
+
+
+PyObj* pyir_builtinEnumerate(PyObj** args, int64_t argc) {}
+
+
+PyObj* pyir_builtinIsInstance(PyObj** args, int64_t argc) {}
+
+
+PyObj* pyir_builtinRange(PyObj** args, int64_t argc) {}
+
+
+PyObj* pyir_builtinType(PyObj** args, int64_t argc) {}
+
+
+PyObj* pyir_builtinZip(PyObj** args, int64_t argc) {}

--- a/src/pyruntime/builtin_runtime.cpp
+++ b/src/pyruntime/builtin_runtime.cpp
@@ -21,6 +21,22 @@
 #include "pyruntime/runtime_util.h"
 
 
+static std::string moduleFile;
+static std::string moduleName;
+
+
+PyObj* pyir_builtinVarName() { return new PyStr(moduleName); }
+
+
+PyObj* pyir_builtinVarFile() { return new PyStr(moduleFile); }
+
+
+void pyir_initModule(const char* file, const char* name) {
+    moduleFile = file;
+    moduleName = name;
+}
+
+
 PyObj* pyir_builtinPrint(PyObj** args, const int64_t argc) {
     for (int64_t i = 0; i < argc; i++) {
         if (i > 0)

--- a/src/pyruntime/memory_runtime.cpp
+++ b/src/pyruntime/memory_runtime.cpp
@@ -41,9 +41,12 @@ void pyir_storeFast(const char* name, PyObj* val) {
 
 
 PyObj* pyir_loadName(const char* name) {
-    // Check for builtins
+    // Check for builtin functions
     if (const auto it = builtinFuncs.find(name); it != builtinFuncs.end())
         return new PyFunction(it->first, it->second);
+    // Check for builtin variables
+    if (const auto it = builtinVars.find(name); it != builtinVars.end())
+        return it->second();
     // Check for names in module scope
     if (const auto it = moduleScope.find(name); it != moduleScope.end()) {
         it->second->incref();

--- a/src/pyruntime/memory_runtime.cpp
+++ b/src/pyruntime/memory_runtime.cpp
@@ -42,7 +42,7 @@ void pyir_storeFast(const char* name, PyObj* val) {
 
 PyObj* pyir_loadName(const char* name) {
     // Check for builtins
-    if (const auto it = builtins.find(name); it != builtins.end())
+    if (const auto it = builtinFuncs.find(name); it != builtinFuncs.end())
         return new PyFunction(it->first, it->second);
     // Check for names in module scope
     if (const auto it = moduleScope.find(name); it != moduleScope.end()) {

--- a/test/conversion/test_builder_codegen.cpp
+++ b/test/conversion/test_builder_codegen.cpp
@@ -14,29 +14,29 @@ TEST_CASE_METHOD(MLIRFixture, "Test F String Format MLIR") {
     const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
     // Check first string component
-    pyir::LoadConst loadConst = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 0));
+    pyir::LoadConst loadConst = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 1));
     REQUIRE(loadConst);
     mlir::StringAttr strAttr = mlir::dyn_cast<mlir::StringAttr>(loadConst.getValue());
     REQUIRE(strAttr);
     REQUIRE(strAttr.getValue() == "Number <<");
 
     // Check constant number
-    pyir::LoadConst loadNumOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 1));
+    pyir::LoadConst loadNumOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 2));
     REQUIRE(loadNumOp);
     mlir::IntegerAttr intAttr = mlir::dyn_cast<mlir::IntegerAttr>(loadNumOp.getValue());
     REQUIRE(intAttr);
     REQUIRE(intAttr.getInt() == 24);
 
-    REQUIRE(mlir::isa<pyir::FormatSimple>(getOp(fn, 2)));
+    REQUIRE(mlir::isa<pyir::FormatSimple>(getOp(fn, 3)));
 
     // Check second string component
-    loadConst = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 3));
+    loadConst = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 4));
     REQUIRE(loadConst);
     strAttr = mlir::dyn_cast<mlir::StringAttr>(loadConst.getValue());
     REQUIRE(strAttr);
     REQUIRE(strAttr.getValue() == ">>");
 
-    pyir::BuildString buildStr = mlir::cast<pyir::BuildString>(getOp(fn, 4));
+    pyir::BuildString buildStr = mlir::cast<pyir::BuildString>(getOp(fn, 5));
     REQUIRE(buildStr);
     REQUIRE(buildStr.getParts().size() == 3);
 }
@@ -48,7 +48,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Build List MLIR") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = []");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
-        pyir::BuildList buildListOp = mlir::dyn_cast<pyir::BuildList>(getOp(fn, 0));
+        pyir::BuildList buildListOp = mlir::dyn_cast<pyir::BuildList>(getOp(fn, 1));
         REQUIRE(buildListOp);
         REQUIRE(buildListOp.getParts().empty());
     }
@@ -57,17 +57,17 @@ TEST_CASE_METHOD(MLIRFixture, "Test Build List MLIR") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = [1, 2, 3]");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
-        pyir::BuildList buildListOp = mlir::dyn_cast<pyir::BuildList>(getOp(fn, 0));
+        pyir::BuildList buildListOp = mlir::dyn_cast<pyir::BuildList>(getOp(fn, 1));
         REQUIRE(buildListOp);
         REQUIRE(buildListOp.getParts().empty());
 
-        pyir::LoadConst loadTupleOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 1));
+        pyir::LoadConst loadTupleOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 2));
         REQUIRE(loadTupleOp);
         mlir::ArrayAttr arrayAttr = mlir::dyn_cast<mlir::ArrayAttr>(loadTupleOp.getValue());
         REQUIRE(arrayAttr);
         REQUIRE(arrayAttr.getValue().size() == 3);
 
-        pyir::ListExtend listExtendOp = mlir::dyn_cast<pyir::ListExtend>(getOp(fn, 2));
+        pyir::ListExtend listExtendOp = mlir::dyn_cast<pyir::ListExtend>(getOp(fn, 3));
         REQUIRE(listExtendOp);
         REQUIRE(mlir::isa<pyir::BuildList>(listExtendOp.getList().getDefiningOp()));
         REQUIRE(mlir::isa<pyir::LoadConst>(listExtendOp.getItems().getDefiningOp()));
@@ -78,17 +78,17 @@ TEST_CASE_METHOD(MLIRFixture, "Test Build List MLIR") {
                 "a = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
-        pyir::BuildList buildListOp = mlir::dyn_cast<pyir::BuildList>(getOp(fn, 0));
+        pyir::BuildList buildListOp = mlir::dyn_cast<pyir::BuildList>(getOp(fn, 1));
         REQUIRE(buildListOp);
         REQUIRE(buildListOp.getParts().empty());
 
-        pyir::LoadConst loadNumOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 1));
+        pyir::LoadConst loadNumOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 2));
         REQUIRE(loadNumOp);
         mlir::IntegerAttr intAttr = mlir::dyn_cast<mlir::IntegerAttr>(loadNumOp.getValue());
         REQUIRE(intAttr);
         REQUIRE(intAttr.getInt() == 1);
 
-        pyir::ListAppend listAppendOp = mlir::dyn_cast<pyir::ListAppend>(getOp(fn, 2));
+        pyir::ListAppend listAppendOp = mlir::dyn_cast<pyir::ListAppend>(getOp(fn, 3));
         REQUIRE(listAppendOp);
         REQUIRE(mlir::isa<pyir::BuildList>(listAppendOp.getList().getDefiningOp()));
         REQUIRE(mlir::isa<pyir::LoadConst>(listAppendOp.getItem().getDefiningOp()));
@@ -102,7 +102,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Build Set MLIR") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = set()");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
-        pyir::LoadName loadNameOp = mlir::dyn_cast<pyir::LoadName>(getOp(fn, 0));
+        pyir::LoadName loadNameOp = mlir::dyn_cast<pyir::LoadName>(getOp(fn, 1));
         REQUIRE(loadNameOp);
         REQUIRE(loadNameOp.getVarName() == "set");
     }
@@ -111,17 +111,17 @@ TEST_CASE_METHOD(MLIRFixture, "Test Build Set MLIR") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = {1, 1, 1}");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
-        pyir::BuildSet buildSetOp = mlir::dyn_cast<pyir::BuildSet>(getOp(fn, 0));
+        pyir::BuildSet buildSetOp = mlir::dyn_cast<pyir::BuildSet>(getOp(fn, 1));
         REQUIRE(buildSetOp);
         REQUIRE(buildSetOp.getParts().empty());
 
-        pyir::LoadConst loadTupleOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 1));
+        pyir::LoadConst loadTupleOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 2));
         REQUIRE(loadTupleOp);
         mlir::ArrayAttr arrayAttr = mlir::dyn_cast<mlir::ArrayAttr>(loadTupleOp.getValue());
         REQUIRE(arrayAttr);
         REQUIRE(arrayAttr.getValue().size() == 1);
 
-        pyir::SetUpdate setUpdateOp = mlir::dyn_cast<pyir::SetUpdate>(getOp(fn, 2));
+        pyir::SetUpdate setUpdateOp = mlir::dyn_cast<pyir::SetUpdate>(getOp(fn, 3));
         REQUIRE(setUpdateOp);
         REQUIRE(mlir::isa<pyir::BuildSet>(setUpdateOp.getSet().getDefiningOp()));
         REQUIRE(mlir::isa<pyir::LoadConst>(setUpdateOp.getItems().getDefiningOp()));
@@ -132,17 +132,17 @@ TEST_CASE_METHOD(MLIRFixture, "Test Build Set MLIR") {
                 "a = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
-        pyir::BuildSet buildSetOp = mlir::dyn_cast<pyir::BuildSet>(getOp(fn, 0));
+        pyir::BuildSet buildSetOp = mlir::dyn_cast<pyir::BuildSet>(getOp(fn, 1));
         REQUIRE(buildSetOp);
         REQUIRE(buildSetOp.getParts().empty());
 
-        pyir::LoadConst loadNumOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 1));
+        pyir::LoadConst loadNumOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 2));
         REQUIRE(loadNumOp);
         mlir::IntegerAttr intAttr = mlir::dyn_cast<mlir::IntegerAttr>(loadNumOp.getValue());
         REQUIRE(intAttr);
         REQUIRE(intAttr.getInt() == 1);
 
-        pyir::SetAdd setAddOp = mlir::dyn_cast<pyir::SetAdd>(getOp(fn, 2));
+        pyir::SetAdd setAddOp = mlir::dyn_cast<pyir::SetAdd>(getOp(fn, 3));
         REQUIRE(setAddOp);
         REQUIRE(mlir::isa<pyir::BuildSet>(setAddOp.getSet().getDefiningOp()));
         REQUIRE(mlir::isa<pyir::LoadConst>(setAddOp.getItem().getDefiningOp()));
@@ -156,7 +156,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Load Tuple MLIR") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = tuple()");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
-        pyir::LoadName loadNameOp = mlir::dyn_cast<pyir::LoadName>(getOp(fn, 0));
+        pyir::LoadName loadNameOp = mlir::dyn_cast<pyir::LoadName>(getOp(fn, 1));
         REQUIRE(loadNameOp);
         REQUIRE(loadNameOp.getVarName() == "tuple");
     }
@@ -165,7 +165,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Load Tuple MLIR") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = (1, 2, 3)");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
-        pyir::LoadConst loadTupleOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 0));
+        pyir::LoadConst loadTupleOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 1));
         REQUIRE(loadTupleOp);
         mlir::ArrayAttr arrayAttr = mlir::dyn_cast<mlir::ArrayAttr>(loadTupleOp.getValue());
         REQUIRE(arrayAttr);
@@ -180,7 +180,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Build Dict MLIR") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = dict()");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
-        pyir::LoadName loadNameOp = mlir::dyn_cast<pyir::LoadName>(getOp(fn, 0));
+        pyir::LoadName loadNameOp = mlir::dyn_cast<pyir::LoadName>(getOp(fn, 1));
         REQUIRE(loadNameOp);
         REQUIRE(loadNameOp.getVarName() == "dict");
     }
@@ -189,19 +189,19 @@ TEST_CASE_METHOD(MLIRFixture, "Test Build Dict MLIR") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = {1: 'one', 2: 'two', 3: 'three'}");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
-        pyir::LoadConst loadNumOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 0));
+        pyir::LoadConst loadNumOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 1));
         REQUIRE(loadNumOp);
         mlir::IntegerAttr intAttr = mlir::dyn_cast<mlir::IntegerAttr>(loadNumOp.getValue());
         REQUIRE(intAttr);
         REQUIRE(intAttr.getInt() == 1);
 
-        pyir::LoadConst loadStrOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 1));
+        pyir::LoadConst loadStrOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 2));
         REQUIRE(loadStrOp);
         mlir::StringAttr StrAttr = mlir::dyn_cast<mlir::StringAttr>(loadStrOp.getValue());
         REQUIRE(StrAttr);
         REQUIRE(StrAttr.str() == "one");
 
-        pyir::BuildMap buildMapOp = mlir::dyn_cast<pyir::BuildMap>(getOp(fn, 6));
+        pyir::BuildMap buildMapOp = mlir::dyn_cast<pyir::BuildMap>(getOp(fn, 7));
         REQUIRE(buildMapOp);
         REQUIRE(buildMapOp.getParts().size() == 6);
     }

--- a/test/conversion/test_control_flow_codegen.cpp
+++ b/test/conversion/test_control_flow_codegen.cpp
@@ -14,10 +14,10 @@ TEST_CASE_METHOD(MLIRFixture, "Test Conditional MLIR") {
     mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
     // Verify Op types
-    REQUIRE(mlir::isa<pyir::IsTruthy>(getOp(fn, 4)));
-    REQUIRE(mlir::isa<mlir::cf::CondBranchOp>(getOp(fn, 5)));
+    REQUIRE(mlir::isa<pyir::IsTruthy>(getOp(fn, 5)));
+    REQUIRE(mlir::isa<mlir::cf::CondBranchOp>(getOp(fn, 6)));
 
-    mlir::cf::CondBranchOp condBr = mlir::cast<mlir::cf::CondBranchOp>(getOp(fn, 5));
+    mlir::cf::CondBranchOp condBr = mlir::cast<mlir::cf::CondBranchOp>(getOp(fn, 6));
     REQUIRE(mlir::isa<pyir::IsTruthy>(condBr.getCondition().getDefiningOp()));
 
     // Verify blocks

--- a/test/conversion/test_function_codegen.cpp
+++ b/test/conversion/test_function_codegen.cpp
@@ -21,23 +21,23 @@ TEST_CASE_METHOD(MLIRFixture, "Test Function Definition MLIR") {
         mlir::func::FuncOp nestedFn = fns[1];
 
         // Validate module-level ops
-        REQUIRE(mlir::isa<pyir::MakeFunction>(getOp(moduleFn, 0)));
-        REQUIRE(mlir::isa<pyir::StoreName>(getOp(moduleFn, 1)));
-        REQUIRE(mlir::isa<pyir::LoadName>(getOp(moduleFn, 2)));
-        REQUIRE(mlir::isa<pyir::PushNull>(getOp(moduleFn, 3)));
-        REQUIRE(mlir::isa<pyir::Call>(getOp(moduleFn, 4)));
-        REQUIRE(mlir::isa<mlir::func::ReturnOp>(getOp(moduleFn, 5)));
+        REQUIRE(mlir::isa<pyir::MakeFunction>(getOp(moduleFn, 1)));
+        REQUIRE(mlir::isa<pyir::StoreName>(getOp(moduleFn, 2)));
+        REQUIRE(mlir::isa<pyir::LoadName>(getOp(moduleFn, 3)));
+        REQUIRE(mlir::isa<pyir::PushNull>(getOp(moduleFn, 4)));
+        REQUIRE(mlir::isa<pyir::Call>(getOp(moduleFn, 5)));
+        REQUIRE(mlir::isa<mlir::func::ReturnOp>(getOp(moduleFn, 6)));
 
         // make_function references the nested fn by name
-        pyir::MakeFunction makeFunc = mlir::cast<pyir::MakeFunction>(getOp(moduleFn, 0));
+        pyir::MakeFunction makeFunc = mlir::cast<pyir::MakeFunction>(getOp(moduleFn, 1));
         REQUIRE(makeFunc.getFnName().starts_with("__pyfn_"));
 
         // store_name stores it as "foo"
-        pyir::StoreName storeName = mlir::cast<pyir::StoreName>(getOp(moduleFn, 1));
+        pyir::StoreName storeName = mlir::cast<pyir::StoreName>(getOp(moduleFn, 2));
         REQUIRE(storeName.getVarName() == "foo");
 
         // call has no args (foo takes no arguments)
-        pyir::Call callOp = mlir::cast<pyir::Call>(getOp(moduleFn, 4));
+        pyir::Call callOp = mlir::cast<pyir::Call>(getOp(moduleFn, 5));
         REQUIRE(callOp.getNumOperands() == 1); // callee only, no args
         // Nested function __pyfn_*
         REQUIRE(nestedFn.getName().starts_with("__pyfn_"));
@@ -85,24 +85,24 @@ TEST_CASE_METHOD(MLIRFixture, "Test Function Definition MLIR") {
         mlir::func::FuncOp nestedFn = fns[1];
 
         // Validate module-level ops
-        REQUIRE(mlir::isa<pyir::MakeFunction>(getOp(moduleFn, 0)));
-        REQUIRE(mlir::isa<pyir::StoreName>(getOp(moduleFn, 1)));
-        REQUIRE(mlir::isa<pyir::LoadName>(getOp(moduleFn, 2)));
-        REQUIRE(mlir::isa<pyir::PushNull>(getOp(moduleFn, 3)));
-        REQUIRE(mlir::isa<pyir::LoadConst>(getOp(moduleFn, 4)));
-        REQUIRE(mlir::isa<pyir::Call>(getOp(moduleFn, 5)));
-        REQUIRE(mlir::isa<mlir::func::ReturnOp>(getOp(moduleFn, 6)));
+        REQUIRE(mlir::isa<pyir::MakeFunction>(getOp(moduleFn, 1)));
+        REQUIRE(mlir::isa<pyir::StoreName>(getOp(moduleFn, 2)));
+        REQUIRE(mlir::isa<pyir::LoadName>(getOp(moduleFn, 3)));
+        REQUIRE(mlir::isa<pyir::PushNull>(getOp(moduleFn, 4)));
+        REQUIRE(mlir::isa<pyir::LoadConst>(getOp(moduleFn, 5)));
+        REQUIRE(mlir::isa<pyir::Call>(getOp(moduleFn, 6)));
+        REQUIRE(mlir::isa<mlir::func::ReturnOp>(getOp(moduleFn, 7)));
 
         // make_function references the nested fn by name
-        pyir::MakeFunction makeFunc = mlir::cast<pyir::MakeFunction>(getOp(moduleFn, 0));
+        pyir::MakeFunction makeFunc = mlir::cast<pyir::MakeFunction>(getOp(moduleFn, 1));
         REQUIRE(makeFunc.getFnName().starts_with("__pyfn_"));
 
         // store_name stores it as "foo"
-        pyir::StoreName storeName = mlir::cast<pyir::StoreName>(getOp(moduleFn, 1));
+        pyir::StoreName storeName = mlir::cast<pyir::StoreName>(getOp(moduleFn, 2));
         REQUIRE(storeName.getVarName() == "foo");
 
         // call has one arg (foo takes one argument)
-        pyir::Call callOp = mlir::cast<pyir::Call>(getOp(moduleFn, 5));
+        pyir::Call callOp = mlir::cast<pyir::Call>(getOp(moduleFn, 6));
         REQUIRE(callOp.getNumOperands() == 2); // callee only, no args
 
         // Nested function __pyfn_*
@@ -151,30 +151,30 @@ TEST_CASE_METHOD(MLIRFixture, "Test Function Definition MLIR") {
         mlir::func::FuncOp nestedFn = fns[1];
 
         // Validate module-level ops
-        REQUIRE(mlir::isa<pyir::MakeFunction>(getOp(moduleFn, 0)));
-        REQUIRE(mlir::isa<pyir::StoreName>(getOp(moduleFn, 1)));
-        REQUIRE(mlir::isa<pyir::LoadName>(getOp(moduleFn, 2)));
-        REQUIRE(mlir::isa<pyir::PushNull>(getOp(moduleFn, 3)));
-        REQUIRE(mlir::isa<pyir::LoadName>(getOp(moduleFn, 4)));
-        REQUIRE(mlir::isa<pyir::PushNull>(getOp(moduleFn, 5)));
-        REQUIRE(mlir::isa<pyir::Call>(getOp(moduleFn, 6)));
+        REQUIRE(mlir::isa<pyir::MakeFunction>(getOp(moduleFn, 1)));
+        REQUIRE(mlir::isa<pyir::StoreName>(getOp(moduleFn, 2)));
+        REQUIRE(mlir::isa<pyir::LoadName>(getOp(moduleFn, 3)));
+        REQUIRE(mlir::isa<pyir::PushNull>(getOp(moduleFn, 4)));
+        REQUIRE(mlir::isa<pyir::LoadName>(getOp(moduleFn, 5)));
+        REQUIRE(mlir::isa<pyir::PushNull>(getOp(moduleFn, 6)));
         REQUIRE(mlir::isa<pyir::Call>(getOp(moduleFn, 7)));
-        REQUIRE(mlir::isa<mlir::func::ReturnOp>(getOp(moduleFn, 8)));
+        REQUIRE(mlir::isa<pyir::Call>(getOp(moduleFn, 8)));
+        REQUIRE(mlir::isa<mlir::func::ReturnOp>(getOp(moduleFn, 9)));
 
         // make_function references the nested fn by name
-        pyir::MakeFunction makeFunc = mlir::cast<pyir::MakeFunction>(getOp(moduleFn, 0));
+        pyir::MakeFunction makeFunc = mlir::cast<pyir::MakeFunction>(getOp(moduleFn, 1));
         REQUIRE(makeFunc.getFnName().starts_with("__pyfn_"));
 
         // store_name stores it as "foo"
-        pyir::StoreName storeName = mlir::cast<pyir::StoreName>(getOp(moduleFn, 1));
+        pyir::StoreName storeName = mlir::cast<pyir::StoreName>(getOp(moduleFn, 2));
         REQUIRE(storeName.getVarName() == "foo");
 
         // call has no args (foo takes no arguments)
-        pyir::Call callOp = mlir::cast<pyir::Call>(getOp(moduleFn, 6));
+        pyir::Call callOp = mlir::cast<pyir::Call>(getOp(moduleFn, 7));
         REQUIRE(callOp.getNumOperands() == 1); // callee only, no args
 
         // load_name inside module is "print"
-        pyir::LoadName loadName = mlir::cast<pyir::LoadName>(getOp(moduleFn, 2));
+        pyir::LoadName loadName = mlir::cast<pyir::LoadName>(getOp(moduleFn, 3));
         REQUIRE(loadName.getVarName() == "print");
 
         // Nested function __pyfn_*
@@ -206,5 +206,16 @@ TEST_CASE_METHOD(MLIRFixture, "Test Bound Method MLIR") {
     SECTION("Test List Append") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("[1, 2].append(3)");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
+
+        pyir::LoadAttr loadAttr = mlir::cast<pyir::LoadAttr>(getOp(fn, 4));
+        REQUIRE(loadAttr);
+        REQUIRE(loadAttr.getAttrName() == "append");
+
+        pyir::LoadConst loadConst = mlir::cast<pyir::LoadConst>(getOp(fn, 6));
+        REQUIRE(loadConst);
+        mlir::IntegerAttr intAttr = mlir::dyn_cast<mlir::IntegerAttr>(loadConst.getValue());
+        REQUIRE(intAttr);
+        REQUIRE(intAttr.getValue() == 3);
+        REQUIRE(mlir::isa<pyir::Call>(getOp(fn, 7)));
     }
 }

--- a/test/conversion/test_logical_codegen.cpp
+++ b/test/conversion/test_logical_codegen.cpp
@@ -13,11 +13,11 @@ TEST_CASE_METHOD(MLIRFixture, "Test Operation Order MLIR") {
     const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2\nb = 2\nc = 3\nd = (a + b) * c");
     const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
-    pyir::BinaryOp addOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 8));
+    pyir::BinaryOp addOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 9));
     REQUIRE(addOp);
     REQUIRE(addOp.getOp() == "+");
 
-    pyir::BinaryOp mulOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 10));
+    pyir::BinaryOp mulOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 11));
     REQUIRE(mulOp);
     REQUIRE(mulOp.getOp() == "*");
 }
@@ -27,7 +27,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Arithmetic Operators MLIR") {
     SECTION("Test Addition") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2\nb = 2\nc = a + b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 6));
+        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "+");
     }
@@ -35,7 +35,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Arithmetic Operators MLIR") {
     SECTION("Test Float Addition") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2.1\nb = 2.1\nc = a + b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 6));
+        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "+");
     }
@@ -43,7 +43,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Arithmetic Operators MLIR") {
     SECTION("Test Subtraction") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2\nb = 2\nc = a - b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 6));
+        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "-");
     }
@@ -51,14 +51,14 @@ TEST_CASE_METHOD(MLIRFixture, "Test Arithmetic Operators MLIR") {
     SECTION("Test Multiplication") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2\nb = 2\nc = a * b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 6));
+        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "*");
     }
     SECTION("Test Division") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2\nb = 2\nc = a / b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 6));
+        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "/");
     }
@@ -66,7 +66,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Arithmetic Operators MLIR") {
     SECTION("Test Floor Division") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2\nb = 2\nc = a // b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 6));
+        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "//");
     }
@@ -74,7 +74,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Arithmetic Operators MLIR") {
     SECTION("Test Exponentiation") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2\nb = 2\nc = a ** b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 6));
+        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "**");
     }
@@ -82,7 +82,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Arithmetic Operators MLIR") {
     SECTION("Test Modulo") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2\nb = 2\nc = a % b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 6));
+        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "%");
     }
@@ -90,14 +90,14 @@ TEST_CASE_METHOD(MLIRFixture, "Test Arithmetic Operators MLIR") {
     SECTION("Test Integer Negation") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = True\nb = -a");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::UnaryNegative unaryOp = mlir::dyn_cast<pyir::UnaryNegative>(getOp(fn, 3));
+        pyir::UnaryNegative unaryOp = mlir::dyn_cast<pyir::UnaryNegative>(getOp(fn, 4));
         REQUIRE(unaryOp);
     }
 
     SECTION("Test Binary Negation") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2\nb = ~a");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::UnaryInvert unaryOp = mlir::dyn_cast<pyir::UnaryInvert>(getOp(fn, 3));
+        pyir::UnaryInvert unaryOp = mlir::dyn_cast<pyir::UnaryInvert>(getOp(fn, 4));
         REQUIRE(unaryOp);
     }
 }
@@ -107,7 +107,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Boolean Operators MLIR") {
     SECTION("Test Boolean Negation") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = True\nb = not a");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::UnaryNot unaryOp = mlir::dyn_cast<pyir::UnaryNot>(getOp(fn, 4));
+        pyir::UnaryNot unaryOp = mlir::dyn_cast<pyir::UnaryNot>(getOp(fn, 5));
         REQUIRE(unaryOp);
     }
 
@@ -116,10 +116,10 @@ TEST_CASE_METHOD(MLIRFixture, "Test Boolean Operators MLIR") {
         mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
         // Verify Op types
-        REQUIRE(mlir::isa<pyir::IsTruthy>(getOp(fn, 6)));
-        REQUIRE(mlir::isa<mlir::cf::CondBranchOp>(getOp(fn, 7)));
+        REQUIRE(mlir::isa<pyir::IsTruthy>(getOp(fn, 7)));
+        REQUIRE(mlir::isa<mlir::cf::CondBranchOp>(getOp(fn, 8)));
 
-        mlir::cf::CondBranchOp condBr = mlir::cast<mlir::cf::CondBranchOp>(getOp(fn, 7));
+        mlir::cf::CondBranchOp condBr = mlir::cast<mlir::cf::CondBranchOp>(getOp(fn, 8));
         REQUIRE(mlir::isa<pyir::IsTruthy>(condBr.getCondition().getDefiningOp()));
 
         // Verify blocks
@@ -146,10 +146,10 @@ TEST_CASE_METHOD(MLIRFixture, "Test Boolean Operators MLIR") {
         mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
         // Verify Op types
-        REQUIRE(mlir::isa<pyir::IsTruthy>(getOp(fn, 6)));
-        REQUIRE(mlir::isa<mlir::cf::CondBranchOp>(getOp(fn, 7)));
+        REQUIRE(mlir::isa<pyir::IsTruthy>(getOp(fn, 7)));
+        REQUIRE(mlir::isa<mlir::cf::CondBranchOp>(getOp(fn, 8)));
 
-        mlir::cf::CondBranchOp condBr = mlir::cast<mlir::cf::CondBranchOp>(getOp(fn, 7));
+        mlir::cf::CondBranchOp condBr = mlir::cast<mlir::cf::CondBranchOp>(getOp(fn, 8));
         REQUIRE(mlir::isa<pyir::IsTruthy>(condBr.getCondition().getDefiningOp()));
 
         // Verify blocks
@@ -174,7 +174,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Boolean Operators MLIR") {
     SECTION("Test Boolean XOR") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = True\nb = True\nc = a ^ b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 6));
+        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "^");
     }
@@ -184,7 +184,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Boolean Operators MLIR") {
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
         // Call op with valid arguments
-        pyir::Call callOp = mlir::dyn_cast<pyir::Call>(getOp(fn, 3));
+        pyir::Call callOp = mlir::dyn_cast<pyir::Call>(getOp(fn, 4));
         REQUIRE(callOp);
         REQUIRE(callOp.getNumOperands() == 2);
 
@@ -201,14 +201,14 @@ TEST_CASE_METHOD(MLIRFixture, "Test Comparators MLIR") {
     SECTION("Test Boolean Negation") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = True\nb = not a");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::UnaryNot unaryOp = mlir::dyn_cast<pyir::UnaryNot>(getOp(fn, 4));
+        pyir::UnaryNot unaryOp = mlir::dyn_cast<pyir::UnaryNot>(getOp(fn, 5));
         REQUIRE(unaryOp);
     }
 
     SECTION("Test Boolean Equality") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = True\nb = True\nc = a == b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 6));
+        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "==");
     }
@@ -216,7 +216,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Comparators MLIR") {
     SECTION("Test Integer Equality") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2\nb = 2\nc = a == b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 6));
+        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "==");
     }
@@ -224,7 +224,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Comparators MLIR") {
     SECTION("Test Float Equality") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2.1\nb = 2.1\nc = a == b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 6));
+        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "==");
     }
@@ -232,7 +232,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Comparators MLIR") {
     SECTION("Test String Equality") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 'g'\nb = 'g'\nc = a == b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 6));
+        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "==");
     }
@@ -240,7 +240,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Comparators MLIR") {
     SECTION("Test Negative Equality") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = True\nb = True\nc = a != b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 6));
+        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "!=");
     }
@@ -248,14 +248,14 @@ TEST_CASE_METHOD(MLIRFixture, "Test Comparators MLIR") {
     SECTION("Test Less Than") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2\nb = 2\nc = a < b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 6));
+        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "<");
     }
     SECTION("Test Less Than Equal") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2\nb = 2\nc = a <= b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 6));
+        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "<=");
     }
@@ -263,7 +263,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Comparators MLIR") {
     SECTION("Test Greater Than") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2\nb = 2\nc = a > b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 6));
+        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == ">");
     }
@@ -271,7 +271,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Comparators MLIR") {
     SECTION("Test Greater Than Equal") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = 2\nb = 2\nc = a >= b");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 6));
+        pyir::CompareOp binaryOp = mlir::dyn_cast<pyir::CompareOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == ">=");
     }
@@ -282,7 +282,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Container Operators MLIR") {
     SECTION("Test Index") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("a = [1, 2]\nb = a[0]");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 6));
+        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 7));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "[]");
     }
@@ -290,7 +290,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Container Operators MLIR") {
     SECTION("Test Membership") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("1 in [1, 2]");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::ContainsOp containsOp = mlir::dyn_cast<pyir::ContainsOp>(getOp(fn, 2));
+        pyir::ContainsOp containsOp = mlir::dyn_cast<pyir::ContainsOp>(getOp(fn, 3));
         REQUIRE(containsOp);
         REQUIRE(containsOp.getOp() == "in");
     }
@@ -298,7 +298,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Container Operators MLIR") {
     SECTION("Test Union") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("{1} | {2}");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 4));
+        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 5));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "|");
     }
@@ -306,7 +306,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Container Operators MLIR") {
     SECTION("Test Intersection") {
         const mlir::OwningOpRef<mlir::ModuleOp> module = compile("{1} & {2}");
         const mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
-        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 4));
+        pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 5));
         REQUIRE(binaryOp);
         REQUIRE(binaryOp.getOp() == "&");
     }

--- a/test/conversion/test_pyir_codegen.cpp
+++ b/test/conversion/test_pyir_codegen.cpp
@@ -14,14 +14,14 @@ TEST_CASE_METHOD(MLIRFixture, "Test Hello World MLIR") {
     mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
     // Verify Op types
-    REQUIRE(mlir::isa<pyir::LoadName>(getOp(fn, 0)));
-    REQUIRE(mlir::isa<pyir::PushNull>(getOp(fn, 1)));
-    REQUIRE(mlir::isa<pyir::LoadConst>(getOp(fn, 2)));
-    REQUIRE(mlir::isa<pyir::Call>(getOp(fn, 3)));
-    REQUIRE(mlir::isa<mlir::func::ReturnOp>(getOp(fn, 4)));
+    REQUIRE(mlir::isa<pyir::LoadName>(getOp(fn, 1)));
+    REQUIRE(mlir::isa<pyir::PushNull>(getOp(fn, 2)));
+    REQUIRE(mlir::isa<pyir::LoadConst>(getOp(fn, 3)));
+    REQUIRE(mlir::isa<pyir::Call>(getOp(fn, 4)));
+    REQUIRE(mlir::isa<mlir::func::ReturnOp>(getOp(fn, 5)));
 
     // Call op with valid arguments
-    pyir::Call callOp = mlir::dyn_cast<pyir::Call>(getOp(fn, 3));
+    pyir::Call callOp = mlir::dyn_cast<pyir::Call>(getOp(fn, 4));
     REQUIRE(callOp);
     REQUIRE(callOp.getNumOperands() == 2);
 
@@ -32,7 +32,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Hello World MLIR") {
     REQUIRE(loadName.getVarName() == "print");
 
     // Print is being called on the correct string
-    pyir::LoadConst loadConst = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 2));
+    pyir::LoadConst loadConst = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 3));
     REQUIRE(loadConst);
     mlir::StringAttr strAttr = mlir::dyn_cast<mlir::StringAttr>(loadConst.getValue());
     REQUIRE(strAttr);
@@ -45,33 +45,33 @@ TEST_CASE_METHOD(MLIRFixture, "Test Simple Arithmetic MLIR") {
     mlir::func::FuncOp fn = *(*module).getBody()->getOps<mlir::func::FuncOp>().begin();
 
     // Verify Op types
-    REQUIRE(mlir::isa<pyir::LoadConst>(getOp(fn, 0)));
-    REQUIRE(mlir::isa<pyir::StoreName>(getOp(fn, 1)));
-    REQUIRE(mlir::isa<pyir::LoadConst>(getOp(fn, 2)));
-    REQUIRE(mlir::isa<pyir::StoreName>(getOp(fn, 3)));
-    REQUIRE(mlir::isa<pyir::LoadName>(getOp(fn, 4)));
+    REQUIRE(mlir::isa<pyir::LoadConst>(getOp(fn, 1)));
+    REQUIRE(mlir::isa<pyir::StoreName>(getOp(fn, 2)));
+    REQUIRE(mlir::isa<pyir::LoadConst>(getOp(fn, 3)));
+    REQUIRE(mlir::isa<pyir::StoreName>(getOp(fn, 4)));
     REQUIRE(mlir::isa<pyir::LoadName>(getOp(fn, 5)));
-    REQUIRE(mlir::isa<pyir::BinaryOp>(getOp(fn, 6)));
-    REQUIRE(mlir::isa<pyir::StoreName>(getOp(fn, 7)));
-    REQUIRE(mlir::isa<pyir::LoadName>(getOp(fn, 8)));
-    REQUIRE(mlir::isa<pyir::PushNull>(getOp(fn, 9)));
-    REQUIRE(mlir::isa<pyir::LoadName>(getOp(fn, 10)));
-    REQUIRE(mlir::isa<pyir::Call>(getOp(fn, 11)));
-    REQUIRE(mlir::isa<mlir::func::ReturnOp>(getOp(fn, 12)));
+    REQUIRE(mlir::isa<pyir::LoadName>(getOp(fn, 6)));
+    REQUIRE(mlir::isa<pyir::BinaryOp>(getOp(fn, 7)));
+    REQUIRE(mlir::isa<pyir::StoreName>(getOp(fn, 8)));
+    REQUIRE(mlir::isa<pyir::LoadName>(getOp(fn, 9)));
+    REQUIRE(mlir::isa<pyir::PushNull>(getOp(fn, 10)));
+    REQUIRE(mlir::isa<pyir::LoadName>(getOp(fn, 11)));
+    REQUIRE(mlir::isa<pyir::Call>(getOp(fn, 12)));
+    REQUIRE(mlir::isa<mlir::func::ReturnOp>(getOp(fn, 13)));
 
     // The integer 1 is being loaded
-    pyir::LoadConst loadOneOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 0));
+    pyir::LoadConst loadOneOp = mlir::dyn_cast<pyir::LoadConst>(getOp(fn, 1));
     REQUIRE(loadOneOp);
     mlir::IntegerAttr intAttr = mlir::dyn_cast<mlir::IntegerAttr>(loadOneOp.getValue());
     REQUIRE(intAttr);
     REQUIRE(intAttr.getInt() == 1);
 
     // The integer is being stored in variable a
-    pyir::StoreName storeAOp = mlir::dyn_cast<pyir::StoreName>(getOp(fn, 1));
+    pyir::StoreName storeAOp = mlir::dyn_cast<pyir::StoreName>(getOp(fn, 2));
     REQUIRE(storeAOp);
     REQUIRE(storeAOp.getVarName() == "a");
     // The binary op is addition
-    pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 6));
+    pyir::BinaryOp binaryOp = mlir::dyn_cast<pyir::BinaryOp>(getOp(fn, 7));
     REQUIRE(binaryOp);
     REQUIRE(binaryOp.getOp() == "+");
 
@@ -86,7 +86,7 @@ TEST_CASE_METHOD(MLIRFixture, "Test Simple Arithmetic MLIR") {
     REQUIRE(rhsLoad.getVarName() == "b");
 
     // Call op with valid arguments
-    pyir::Call callOp = mlir::dyn_cast<pyir::Call>(getOp(fn, 11));
+    pyir::Call callOp = mlir::dyn_cast<pyir::Call>(getOp(fn, 12));
     REQUIRE(callOp);
     REQUIRE(callOp.getNumOperands() == 2);
 

--- a/test/execution/execution_test_utils.h
+++ b/test/execution/execution_test_utils.h
@@ -15,6 +15,7 @@
 #include "lowering/pyir_lowering.h"
 #include "pyir_run_module.h"
 #include "pyruntime/builder_runtime.h"
+#include "pyruntime/builtin_runtime.h"
 #include "pyruntime/function_runtime.h"
 #include "pyruntime/logical_runtime.h"
 #include "pyruntime/memory_runtime.h"
@@ -97,6 +98,7 @@ struct JITFixture {
         };
 
         // Register all runtime functions
+        addSymbol("pyir_initModule", reinterpret_cast<void*>(pyir_initModule));
         addSymbol("pyir_loadName", reinterpret_cast<void*>(pyir_loadName));
         addSymbol("pyir_storeName", reinterpret_cast<void*>(pyir_storeName));
         addSymbol("pyir_loadFast", reinterpret_cast<void*>(pyir_loadFast));

--- a/test/execution/execution_test_utils.h
+++ b/test/execution/execution_test_utils.h
@@ -145,6 +145,11 @@ struct JITFixture {
         addSymbol("pyir_setAdd", reinterpret_cast<void*>(pyir_setAdd));
         addSymbol("pyir_buildMap", reinterpret_cast<void*>(pyir_buildMap));
         addSymbol("pyir_storeSubscr", reinterpret_cast<void*>(pyir_storeSubscr));
+        addSymbol("pyir_builtinEnumerate", reinterpret_cast<void*>(pyir_builtinEnumerate));
+        addSymbol("pyir_builtinIsInstance", reinterpret_cast<void*>(pyir_builtinIsInstance));
+        addSymbol("pyir_builtinRange", reinterpret_cast<void*>(pyir_builtinRange));
+        addSymbol("pyir_builtinType", reinterpret_cast<void*>(pyir_builtinType));
+        addSymbol("pyir_builtinZip", reinterpret_cast<void*>(pyir_builtinZip));
 
         // Symbols for test error handling
         addSymbol("pyir_runModule", reinterpret_cast<void*>(pyir_runModule));

--- a/test/execution/test_builtin_execution.cpp
+++ b/test/execution/test_builtin_execution.cpp
@@ -9,10 +9,10 @@
 
 TEST_CASE_METHOD(JITFixture, "Test JIT Range") {
     std::string output = runCapture("print(range(5))");
-    REQUIRE(output == "[0, 1, 2, 3, 4]\n");
+    REQUIRE(output == "(0, 1, 2, 3, 4)\n");
 
     output = runCapture("print(range(3, 5))");
-    REQUIRE(output == "[3, 4]\n");
+    REQUIRE(output == "(3, 4)\n");
 }
 
 TEST_CASE_METHOD(JITFixture, "Test JIT Enumerate") {

--- a/test/execution/test_builtin_execution.cpp
+++ b/test/execution/test_builtin_execution.cpp
@@ -1,0 +1,76 @@
+//
+// Created by matthew on 3/22/26.
+//
+
+#include <catch2/catch_all.hpp>
+
+#include "execution_test_utils.h"
+
+
+TEST_CASE_METHOD(JITFixture, "Test JIT Range") {
+    std::string output = runCapture("print(range(5))");
+    REQUIRE(output == "[0, 1, 2, 3, 4]\n");
+
+    output = runCapture("print(range(3, 5))");
+    REQUIRE(output == "[3, 4]\n");
+}
+
+TEST_CASE_METHOD(JITFixture, "Test JIT Enumerate") {
+    const std::string output = runCapture("print(enumerate(['zero', 'one', 'two']))");
+    REQUIRE(output == "[(0, 'zero'), (1, 'one'), (2, 'two')]\n");
+}
+
+TEST_CASE_METHOD(JITFixture, "Test JIT Zip") {
+    const std::string output = runCapture("print(zip([1, 2, 3], ['a', 'b', 'c']))");
+    REQUIRE(output == "[(1, 'a'), (2, 'b'), (3, 'c')]\n");
+}
+
+TEST_CASE_METHOD(JITFixture, "Test JIT Type") {
+    SECTION("Test Type Str") {
+        const std::string output = runCapture("print(type(''))");
+        REQUIRE(output == "<class 'str'>\n");
+    }
+
+    SECTION("Test Type List") {
+        const std::string output = runCapture("print(type([]))");
+        REQUIRE(output == "<class 'list'>\n");
+    }
+
+    SECTION("Test Type Set") {
+        const std::string output = runCapture("print(type(set()))");
+        REQUIRE(output == "<class 'set'>\n");
+    }
+
+    SECTION("Test Type Dict") {
+        const std::string output = runCapture("print(type({}))");
+        REQUIRE(output == "<class 'dict'>\n");
+    }
+
+    SECTION("Test Type Tuple") {
+        const std::string output = runCapture("print(type(()))");
+        REQUIRE(output == "<class 'tuple'>\n");
+    }
+
+    SECTION("Test Type Iter") {
+        const std::string output = runCapture("print(type(iter([])))");
+        REQUIRE(output == "<class 'list_iterator'>\n");
+    }
+}
+
+TEST_CASE_METHOD(JITFixture, "Test JIT Is Instance") {
+    std::string output = runCapture("isinstance([], list)");
+    REQUIRE(output == "True\n");
+
+    output = runCapture("isinstance({}, list)");
+    REQUIRE(output == "False\n");
+}
+
+TEST_CASE_METHOD(JITFixture, "Test JIT Name") {
+    const std::string output = runCapture("print(__name__)");
+    REQUIRE(output == "__main__\n");
+}
+
+TEST_CASE_METHOD(JITFixture, "Test JIT File") {
+    const std::string output = runCapture("print(__file__)");
+    REQUIRE(output == "<embedded>\n");
+}

--- a/test/execution/test_builtin_execution.cpp
+++ b/test/execution/test_builtin_execution.cpp
@@ -21,8 +21,25 @@ TEST_CASE_METHOD(JITFixture, "Test JIT Enumerate") {
 }
 
 TEST_CASE_METHOD(JITFixture, "Test JIT Zip") {
-    const std::string output = runCapture("print(zip([1, 2, 3], ['a', 'b', 'c']))");
-    REQUIRE(output == "[(1, 'a'), (2, 'b'), (3, 'c')]\n");
+    SECTION("Test Zip List") {
+        const std::string output = runCapture("print(zip([1, 2, 3]))");
+        REQUIRE(output == "[(1,), (2,), (3,)]\n");
+    }
+
+    SECTION("Test Zip List Tuple") {
+        const std::string output = runCapture("print(zip([1, 2, 3], ('a', 'b', 'c')))");
+        REQUIRE(output == "[(1, 'a'), (2, 'b'), (3, 'c')]\n");
+    }
+
+    SECTION("Test Zip List Dict") {
+        const std::string output = runCapture("print(zip([1, 2, 3], {'a': 1, 'b': 2, 'c': 3}))");
+        REQUIRE(output == "[(1, 'a'), (2, 'b'), (3, 'c')]\n");
+    }
+
+    SECTION("Test Zip List Tuple Dict") {
+        const std::string output = runCapture("print(zip([1, 2, 3], (1.1, 2.2, 3.3, 4.4), {'a': 1, 'b': 2, 'c': 3}))");
+        REQUIRE(output == "[(1, 1.1, 'a'), (2, 2.2, 'b'), (3, 3.3, 'c')]\n");
+    }
 }
 
 TEST_CASE_METHOD(JITFixture, "Test JIT Type") {
@@ -60,7 +77,7 @@ TEST_CASE_METHOD(JITFixture, "Test JIT Type") {
         const std::string output = runCapture("print(type(iter([])))");
         REQUIRE(output == "<class 'list_iterator'>\n");
     }
- SECTION("Test Type Dict Iter") {
+    SECTION("Test Type Dict Iter") {
         const std::string output = runCapture("print(type(iter({})))");
         REQUIRE(output == "<class 'dict_iterator'>\n");
     }

--- a/test/execution/test_builtin_execution.cpp
+++ b/test/execution/test_builtin_execution.cpp
@@ -58,10 +58,10 @@ TEST_CASE_METHOD(JITFixture, "Test JIT Type") {
 }
 
 TEST_CASE_METHOD(JITFixture, "Test JIT Is Instance") {
-    std::string output = runCapture("isinstance([], list)");
+    std::string output = runCapture("print(isinstance([], list))");
     REQUIRE(output == "True\n");
 
-    output = runCapture("isinstance({}, list)");
+    output = runCapture("print(isinstance({}, list))");
     REQUIRE(output == "False\n");
 }
 

--- a/test/execution/test_builtin_execution.cpp
+++ b/test/execution/test_builtin_execution.cpp
@@ -51,9 +51,28 @@ TEST_CASE_METHOD(JITFixture, "Test JIT Type") {
         REQUIRE(output == "<class 'tuple'>\n");
     }
 
-    SECTION("Test Type Iter") {
+    SECTION("Test Type Str Iter") {
+        const std::string output = runCapture("print(type(iter('')))");
+        REQUIRE(output == "<class 'str_iterator'>\n");
+    }
+
+    SECTION("Test Type List Iter") {
         const std::string output = runCapture("print(type(iter([])))");
         REQUIRE(output == "<class 'list_iterator'>\n");
+    }
+ SECTION("Test Type Dict Iter") {
+        const std::string output = runCapture("print(type(iter({})))");
+        REQUIRE(output == "<class 'dict_iterator'>\n");
+    }
+
+    SECTION("Test Type Set Iter") {
+        const std::string output = runCapture("print(type(iter(set())))");
+        REQUIRE(output == "<class 'set_iterator'>\n");
+    }
+
+    SECTION("Test Type Tuple Iter") {
+        const std::string output = runCapture("print(type(iter(())))");
+        REQUIRE(output == "<class 'tuple_iterator'>\n");
     }
 }
 

--- a/test/execution/test_iter_execution.cpp
+++ b/test/execution/test_iter_execution.cpp
@@ -9,27 +9,27 @@
 
 TEST_CASE_METHOD(JITFixture, "Test JIT Iter Str Creation") {
     const std::string output = runCapture("print(iter('123'))");
-    REQUIRE(output == "<iterator>\n");
+    REQUIRE(output == "<str_iterator>\n");
 }
 
 TEST_CASE_METHOD(JITFixture, "Test JIT Iter List Creation") {
     const std::string output = runCapture("print(iter([1, 2, 3]))");
-    REQUIRE(output == "<iterator>\n");
+    REQUIRE(output == "<list_iterator>\n");
 }
 
 TEST_CASE_METHOD(JITFixture, "Test JIT Iter Set Creation") {
     const std::string output = runCapture("print(iter({1, 2, 3}))");
-    REQUIRE(output == "<iterator>\n");
+    REQUIRE(output == "<set_iterator>\n");
 }
 
 TEST_CASE_METHOD(JITFixture, "Test JIT Iter Dict Creation") {
     const std::string output = runCapture("print(iter({1: 'one', 2: 'two', 3: 'three'}))");
-    REQUIRE(output == "<iterator>\n");
+    REQUIRE(output == "<dict_iterator>\n");
 }
 
 TEST_CASE_METHOD(JITFixture, "Test JIT Iter Tuple Creation") {
     const std::string output = runCapture("print(iter((1, 2, 3)))");
-    REQUIRE(output == "<iterator>\n");
+    REQUIRE(output == "<tuple_iterator>\n");
 }
 
 TEST_CASE_METHOD(JITFixture, "Test JIT Empty Iterator") {


### PR DESCRIPTION
# Summary

This PR adds `__name__`, `__file__`, `range()`, `enumerate()`, `type()`, `isinstance()`, and `zip()` builtins.

## Related Issue(s)

* #40 

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Test or fixture update
* [ ] Reorganization or Refactor