### PR TITLE
79 feature add custom path for standard library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,8 +82,4 @@ target_include_directories(pycompile SYSTEM PRIVATE
 set_target_properties(pycompile PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
-target_compile_definitions(pycompile PRIVATE
-        "PYIR_RUNTIME_LIB_PATH=\"${CMAKE_BINARY_DIR}/lib/libstdpyir.a\""
-        "PYIR_RUNTIME_MAIN_PATH=\"${CMAKE_BINARY_DIR}/lib/libpyirmain.a\""
-)
 add_dependencies(pycompile stdpyir pyirmain)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,4 +82,8 @@ target_include_directories(pycompile SYSTEM PRIVATE
 set_target_properties(pycompile PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
+target_compile_definitions(pycompile PRIVATE
+        "PYIR_RUNTIME_LIB=\"stdpyir\""
+        "PYIR_RUNTIME_MAIN=\"pyirmain\""
+)
 add_dependencies(pycompile stdpyir pyirmain)

--- a/src/lowering/llvm_export.cpp
+++ b/src/lowering/llvm_export.cpp
@@ -25,6 +25,23 @@
 
 #include "utils.h"
 
+// Helper methods that return the macro if defined or fail with an error if not
+std::string pyRuntimeLib() {
+#ifndef PYIR_RUNTIME_LIB
+    throw std::runtime_error("error: macro PYIR_RUNTIME_LIB not defined");
+#else
+    return PYIR_RUNTIME_LIB;
+#endif
+}
+
+std::string pyRuntimeMain() {
+#ifndef PYIR_RUNTIME_MAIN
+    throw std::runtime_error("error: macro PYIR_RUNTIME_MAIN not defined");
+#else
+    return PYIR_RUNTIME_MAIN;
+#endif
+}
+
 /**
  * Initializes LLVM's native target, ASM printer, and ASM parser. Safe to call multiple times: LLVM initialization
  * is idempotent.
@@ -189,9 +206,9 @@ void linkObjectFile(const std::filesystem::path& obj, const std::filesystem::pat
 
     const std::string objStr = obj.string();
     const std::string outStr = output.string();
-    const std::string runtimeLib = PYIR_RUNTIME_LIB_PATH;
-    const std::string runtimeMain = PYIR_RUNTIME_MAIN_PATH;
-    const std::vector<llvm::StringRef> args = {*cppCompiler, objStr, runtimeLib, runtimeMain, "-o", outStr};
+    const std::string runtimeLib = pyRuntimeLib();
+    const std::string runtimeMain = pyRuntimeMain();
+    const std::vector<llvm::StringRef> args = {*cppCompiler, objStr, "-l", runtimeLib, "-l", runtimeMain, "-o", outStr};
 
     std::string errMsg;
     int ret = llvm::sys::ExecuteAndWait(*cppCompiler, args, std::nullopt, {}, 0, 0, &errMsg);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,10 +30,6 @@ target_include_directories(pycompile-tests SYSTEM PRIVATE
         ${MLIR_INCLUDE_DIRS}
         ${LLVM_INCLUDE_DIRS}
 )
-target_compile_definitions(pycompile-tests PRIVATE
-        "PYIR_RUNTIME_LIB_PATH=\"${CMAKE_BINARY_DIR}/lib/libstdpyir.a\""
-        "PYIR_RUNTIME_MAIN_PATH=\"${CMAKE_BINARY_DIR}/lib/libpyirmain.a\""
-)
 
 include(CTest)
 include(Catch)


### PR DESCRIPTION
# Summary

This PR removes the hard-coded library paths. The runtime and main libraries are now found through `$LIBRARY_PATH` or a standard library directory.

## Related Issue(s)

* #79

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Test or fixture update
* [ ] Reorganization or Refactor
