### PR TITLE
Upgrade to LLVM 22

### DIFF
--- a/include/conversion/memory_codegen.h
+++ b/include/conversion/memory_codegen.h
@@ -97,8 +97,8 @@ void storeSubscrCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, Con
 /**
  * Converts a STORE_FAST_LOAD_FAST bytecode instruction to pyir::StoreFast followed by pyir::LoadFast.
  */
-void storeFastLoadFastCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
-                              const ByteCodeInstruction& instr, ConversionMeta& meta);
+void storeFastLoadFastCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, const ByteCodeInstruction& instr,
+                              ConversionMeta& meta);
 
 
 /**

--- a/include/pyir/pyir_ops.h
+++ b/include/pyir/pyir_ops.h
@@ -16,6 +16,7 @@
 #include "pyir/pyir_types.h"
 
 #define GET_OP_CLASSES
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "pyir_ops.h.inc"
 #undef GET_OP_CLASSES
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,7 @@ target_include_directories(pycompile SYSTEM PRIVATE
 )
 set_target_properties(pycompile PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+        COMPILE_WARNING_AS_ERROR ON
 )
 target_compile_definitions(pycompile PRIVATE
         "PYIR_RUNTIME_LIB=\"stdpyir\""

--- a/src/conversion/builder_codegen.cpp
+++ b/src/conversion/builder_codegen.cpp
@@ -8,7 +8,7 @@
 
 void buildStringCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                         const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const int64_t* count = std::get_if<int64_t>(&instr.argval);
     if (!count)
         throw std::runtime_error("BUILD_STRING must have an int argval");
@@ -18,13 +18,13 @@ void buildStringCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const 
         parts[i] = meta.stack.back();
         meta.stack.pop_back();
     }
-    meta.stack.push_back(builder.create<pyir::BuildString>(loc, pyType, parts).getResult());
+    meta.stack.push_back(pyir::BuildString::create(builder, loc, pyType, parts).getResult());
 }
 
 
 void buildListCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                       const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const int64_t* count = std::get_if<int64_t>(&instr.argval);
     if (!count)
         throw std::runtime_error("BUILD_LIST must have an int argval");
@@ -34,7 +34,7 @@ void buildListCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const ml
         parts[i] = meta.stack.back();
         meta.stack.pop_back();
     }
-    meta.stack.push_back(builder.create<pyir::BuildList>(loc, pyType, parts).getResult());
+    meta.stack.push_back(pyir::BuildList::create(builder, loc, pyType, parts).getResult());
 }
 
 
@@ -47,8 +47,8 @@ void listExtendCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, cons
     const mlir::Value items = meta.stack.back();
     meta.stack.pop_back();
 
-    mlir::Value list = meta.stack.at(meta.stack.size() - *idx);
-    builder.create<pyir::ListExtend>(loc, list, items);
+    const mlir::Value list = meta.stack.at(meta.stack.size() - *idx);
+    pyir::ListExtend::create(builder, loc, list, items);
 }
 
 
@@ -61,14 +61,14 @@ void listAppendCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, cons
     const mlir::Value item = meta.stack.back();
     meta.stack.pop_back();
 
-    mlir::Value list = meta.stack.at(meta.stack.size() - *idx);
-    builder.create<pyir::ListAppend>(loc, list, item);
+    const mlir::Value list = meta.stack.at(meta.stack.size() - *idx);
+    pyir::ListAppend::create(builder, loc, list, item);
 }
 
 
 void buildSetCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                      const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const int64_t* count = std::get_if<int64_t>(&instr.argval);
     if (!count)
         throw std::runtime_error("BUILD_SET must have an int argval");
@@ -78,7 +78,7 @@ void buildSetCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mli
         parts[i] = meta.stack.back();
         meta.stack.pop_back();
     }
-    meta.stack.push_back(builder.create<pyir::BuildSet>(loc, pyType, parts).getResult());
+    meta.stack.push_back(pyir::BuildSet::create(builder, loc, pyType, parts).getResult());
 }
 
 
@@ -91,8 +91,8 @@ void setUpdateCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, const
     const mlir::Value items = meta.stack.back();
     meta.stack.pop_back();
 
-    mlir::Value set = meta.stack.at(meta.stack.size() - *idx);
-    builder.create<pyir::SetUpdate>(loc, set, items);
+    const mlir::Value set = meta.stack.at(meta.stack.size() - *idx);
+    pyir::SetUpdate::create(builder, loc, set, items);
 }
 
 
@@ -105,14 +105,14 @@ void setAddCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, const By
     const mlir::Value item = meta.stack.back();
     meta.stack.pop_back();
 
-    mlir::Value set = meta.stack.at(meta.stack.size() - *idx);
-    builder.create<pyir::SetAdd>(loc, set, item);
+    const mlir::Value set = meta.stack.at(meta.stack.size() - *idx);
+    pyir::SetAdd::create(builder, loc, set, item);
 }
 
 
 void buildMapCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                      const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const int64_t* countPtr = std::get_if<int64_t>(&instr.argval);
     if (!countPtr)
         throw std::runtime_error("BUILD_MAP must have an int argval");
@@ -124,7 +124,7 @@ void buildMapCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mli
         parts[i] = meta.stack.back();
         meta.stack.pop_back();
     }
-    meta.stack.push_back(builder.create<pyir::BuildMap>(loc, pyType, parts).getResult());
+    meta.stack.push_back(pyir::BuildMap::create(builder, loc, pyType, parts).getResult());
 }
 
 
@@ -139,6 +139,6 @@ void mapAddCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, const By
     const mlir::Value key = meta.stack.back();
     meta.stack.pop_back();
 
-    mlir::Value dict = meta.stack.at(meta.stack.size() - *idx);
-    builder.create<pyir::MapAdd>(loc, dict, key, value);
+    const mlir::Value dict = meta.stack.at(meta.stack.size() - *idx);
+    pyir::MapAdd::create(builder, loc, dict, key, value);
 }

--- a/src/conversion/control_flow_codegen.cpp
+++ b/src/conversion/control_flow_codegen.cpp
@@ -17,7 +17,7 @@ void jumpForwardCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, con
     if (!target)
         throw PyCompileError("JUMP_FORWARD must have an int argval", loc);
     mlir::Block* dest = meta.offsetToBlock.at(*target);
-    builder.create<mlir::cf::BranchOp>(loc, dest);
+    mlir::cf::BranchOp::create(builder, loc, dest);
 }
 
 
@@ -34,7 +34,7 @@ void jumpBackwardCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, co
         for (mlir::Value v : branchArgs)
             dest->addArgument(v.getType(), loc);
 
-    builder.create<mlir::cf::BranchOp>(loc, dest, mlir::ValueRange{branchArgs});
+    mlir::cf::BranchOp::create(builder, loc, dest, mlir::ValueRange{branchArgs});
 }
 
 
@@ -43,11 +43,11 @@ void jumpBackwardCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, co
  */
 inline void popJumpIfCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, mlir::func::FuncOp& fn,
                              const int64_t* target, const bool truthy, ConversionMeta& meta) {
-    mlir::Value cond = meta.stack.back();
+    const mlir::Value cond = meta.stack.back();
     meta.stack.pop_back();
 
     // unbox !pyir.object -> i1
-    mlir::Value i1cond = builder.create<pyir::IsTruthy>(loc, builder.getI1Type(), cond).getResult();
+    const mlir::Value i1cond = pyir::IsTruthy::create(builder, loc, builder.getI1Type(), cond).getResult();
     mlir::Block* ifBlock = meta.offsetToBlock.at(*target);
     mlir::Block* elseBlock = fn.addBlock();
 
@@ -62,11 +62,11 @@ inline void popJumpIfCodegen(mlir::OpBuilder& builder, const mlir::Location& loc
             ifBlock->addArgument(t, loc);
 
     if (truthy)
-        builder.create<mlir::cf::CondBranchOp>(loc, i1cond, ifBlock, mlir::ValueRange{ifArgs}, elseBlock,
-                                               mlir::ValueRange{});
+        mlir::cf::CondBranchOp::create(builder, loc, i1cond, ifBlock, mlir::ValueRange{ifArgs}, elseBlock,
+                                       mlir::ValueRange{});
     else
-        builder.create<mlir::cf::CondBranchOp>(loc, i1cond, elseBlock, mlir::ValueRange{}, ifBlock,
-                                               mlir::ValueRange{ifArgs});
+        mlir::cf::CondBranchOp::create(builder, loc, i1cond, elseBlock, mlir::ValueRange{}, ifBlock,
+                                       mlir::ValueRange{ifArgs});
     builder.setInsertionPointToStart(elseBlock);
 }
 
@@ -90,10 +90,10 @@ void popJumpIfFalseCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, 
 
 
 void getIterCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
-    mlir::Value container = meta.stack.back();
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const mlir::Value container = meta.stack.back();
     meta.stack.pop_back(); // Replace value
-    meta.stack.push_back(builder.create<pyir::GetIter>(loc, pyType, container).getResult());
+    meta.stack.push_back(pyir::GetIter::create(builder, loc, pyType, container).getResult());
 }
 
 
@@ -104,7 +104,7 @@ void forIterCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir
         throw PyCompileError("FOR_ITER must have an int argval", loc);
 
     // Get iterator for instruction
-    mlir::Value iterator = meta.stack.back();
+    const mlir::Value iterator = meta.stack.back();
 
     mlir::Block* exitBlock = meta.offsetToBlock.at(*target);
     mlir::Block* bodyBlock = fn.addBlock();
@@ -119,7 +119,7 @@ void forIterCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir
         for (mlir::Value v : exitArgs)
             exitBlock->addArgument(v.getType(), loc);
 
-    builder.create<pyir::ForIter>(loc, iterator, exitArgs, bodyBlock, exitBlock);
+    pyir::ForIter::create(builder, loc, iterator, exitArgs, bodyBlock, exitBlock);
 
     // Continue in body block with next value on stack
     builder.setInsertionPointToStart(bodyBlock);
@@ -127,4 +127,4 @@ void forIterCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir
     meta.stack.push_back(bodyBlock->getArgument(0));
 }
 
-void popIterCodegen(mlir::OpBuilder& builder, const mlir::Location& loc) { builder.create<pyir::PopIter>(loc); }
+void popIterCodegen(mlir::OpBuilder& builder, const mlir::Location& loc) { pyir::PopIter::create(builder, loc); }

--- a/src/conversion/function_codegen.cpp
+++ b/src/conversion/function_codegen.cpp
@@ -14,7 +14,7 @@
 
 void makeFunctionCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                          ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const mlir::Value sentinel = meta.stack.back();
     meta.stack.pop_back();
 
@@ -23,13 +23,13 @@ void makeFunctionCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const
     // Erase the sentinel PushNull op since it was just a placeholder
     sentinel.getDefiningOp()->erase();
 
-    meta.stack.push_back(builder.create<pyir::MakeFunction>(loc, pyType, fnName).getResult());
+    meta.stack.push_back(pyir::MakeFunction::create(builder, loc, pyType, fnName).getResult());
 }
 
 
 void callFuncCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                      const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const int64_t* argc = std::get_if<int64_t>(&instr.argval);
     if (!argc)
         throw PyCompileError("CALL must have an int argval", loc);
@@ -41,10 +41,10 @@ void callFuncCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mli
     }
 
     meta.stack.pop_back(); // Null sentinel
-    mlir::Value callee = meta.stack.back();
+    const mlir::Value callee = meta.stack.back();
     meta.stack.pop_back(); // Actual callee
 
-    meta.stack.push_back(builder.create<pyir::Call>(loc, pyType, callee, args).getResult());
+    meta.stack.push_back(pyir::Call::create(builder, loc, pyType, callee, args).getResult());
 }
 
 
@@ -57,13 +57,13 @@ void returnValueCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, Con
 
     // Pop the local scope before returning from a function (not needed at module level)
     if (meta.isFunction)
-        builder.create<pyir::PopScope>(loc);
+        pyir::PopScope::create(builder, loc);
     // Emit destroy module instruction at the end of a top level module
     else
-        builder.create<pyir::DestroyModule>(loc);
+        pyir::DestroyModule::create(builder, loc);
 
     if (retVal)
-        builder.create<pyir::ReturnValue>(loc, retVal);
+        pyir::ReturnValue::create(builder, loc, retVal);
     else
-        builder.create<mlir::func::ReturnOp>(loc);
+        mlir::func::ReturnOp::create(builder, loc);
 }

--- a/src/conversion/logical_codegen.cpp
+++ b/src/conversion/logical_codegen.cpp
@@ -10,85 +10,85 @@
 
 void binaryOpCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                      const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const std::string opStr = instr.argrepr;
     if (opStr.empty())
         throw PyCompileError("BINARY_OP must have a string argval", loc);
-    mlir::Value rhs = meta.stack.back();
+    const mlir::Value rhs = meta.stack.back();
     meta.stack.pop_back();
-    mlir::Value lhs = meta.stack.back();
+    const mlir::Value lhs = meta.stack.back();
     meta.stack.pop_back();
-    meta.stack.push_back(builder.create<pyir::BinaryOp>(loc, pyType, opStr, lhs, rhs).getResult());
+    meta.stack.push_back(pyir::BinaryOp::create(builder, loc, pyType, opStr, lhs, rhs).getResult());
 }
 
 
 void compareOpCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                       const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const std::string opStr = instr.argrepr;
     if (opStr.empty())
         throw PyCompileError("COMPARE_OP must have a string argval", loc);
-    mlir::Value rhs = meta.stack.back();
+    const mlir::Value rhs = meta.stack.back();
     meta.stack.pop_back();
-    mlir::Value lhs = meta.stack.back();
+    const mlir::Value lhs = meta.stack.back();
     meta.stack.pop_back();
-    meta.stack.push_back(builder.create<pyir::CompareOp>(loc, pyType, opStr, lhs, rhs).getResult());
+    meta.stack.push_back(pyir::CompareOp::create(builder, loc, pyType, opStr, lhs, rhs).getResult());
 }
 
 
 void containsOpCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                        const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const std::string opStr = instr.argrepr;
     if (opStr.empty())
         throw PyCompileError("CONTAINS_OP must have a string argval", loc);
-    mlir::Value container = meta.stack.back();
+    const mlir::Value container = meta.stack.back();
     meta.stack.pop_back();
-    mlir::Value element = meta.stack.back();
+    const mlir::Value element = meta.stack.back();
     meta.stack.pop_back();
-    meta.stack.push_back(builder.create<pyir::ContainsOp>(loc, pyType, opStr, container, element).getResult());
+    meta.stack.push_back(pyir::ContainsOp::create(builder, loc, pyType, opStr, container, element).getResult());
 }
 
 
 void toBoolCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
-    mlir::Value toConvert = meta.stack.back();
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const mlir::Value toConvert = meta.stack.back();
     meta.stack.pop_back(); // Replace value
-    meta.stack.push_back(builder.create<pyir::ToBool>(loc, pyType, toConvert).getResult());
+    meta.stack.push_back(pyir::ToBool::create(builder, loc, pyType, toConvert).getResult());
 }
 
 
 void unaryNotCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                      ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
-    mlir::Value value = meta.stack.back();
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const mlir::Value value = meta.stack.back();
     meta.stack.pop_back();
-    meta.stack.push_back(builder.create<pyir::UnaryNot>(loc, pyType, value).getResult());
+    meta.stack.push_back(pyir::UnaryNot::create(builder, loc, pyType, value).getResult());
 }
 
 
 void unaryNegativeCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                           ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
-    mlir::Value value = meta.stack.back();
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const mlir::Value value = meta.stack.back();
     meta.stack.pop_back();
-    meta.stack.push_back(builder.create<pyir::UnaryNegative>(loc, pyType, value).getResult());
+    meta.stack.push_back(pyir::UnaryNegative::create(builder, loc, pyType, value).getResult());
 }
 
 
 void unaryInvertCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                         ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
-    mlir::Value value = meta.stack.back();
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const mlir::Value value = meta.stack.back();
     meta.stack.pop_back();
-    meta.stack.push_back(builder.create<pyir::UnaryInvert>(loc, pyType, value).getResult());
+    meta.stack.push_back(pyir::UnaryInvert::create(builder, loc, pyType, value).getResult());
 }
 
 
 void formatSimpleCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                          ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
-    mlir::Value val = meta.stack.back();
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const mlir::Value val = meta.stack.back();
     meta.stack.pop_back();
-    meta.stack.push_back(builder.create<pyir::FormatSimple>(loc, pyType, val).getResult());
+    meta.stack.push_back(pyir::FormatSimple::create(builder, loc, pyType, val).getResult());
 }

--- a/src/conversion/memory_codegen.cpp
+++ b/src/conversion/memory_codegen.cpp
@@ -37,45 +37,45 @@ std::string resolveDeref(const CodeInfo& info, const int64_t idx) {
 
 void loadSmallIntCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                          const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const int64_t* target = std::get_if<int64_t>(&instr.argval);
     if (!target)
         throw PyCompileError("LOAD_SMALL_INT must have an int argval", loc);
-    mlir::Attribute attr = builder.getI64IntegerAttr(*target);
-    meta.stack.push_back(builder.create<pyir::LoadConst>(loc, pyType, attr).getResult());
+    const mlir::Attribute attr = builder.getI64IntegerAttr(*target);
+    meta.stack.push_back(pyir::LoadConst::create(builder, loc, pyType, attr).getResult());
 }
 
 
 void loadGlobalCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                        const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const std::string* name = std::get_if<std::string>(&instr.argval);
     if (!name)
         throw PyCompileError("LOAD_GLOBAL must have a string argval", loc);
     // Push the value
-    meta.stack.push_back(builder.create<pyir::LoadName>(loc, pyType, *name).getResult());
+    meta.stack.push_back(pyir::LoadName::create(builder, loc, pyType, *name).getResult());
     // LOAD_GLOBAL also pushes a null sentinel
-    meta.stack.push_back(builder.create<pyir::PushNull>(loc, pyType).getResult());
+    meta.stack.push_back(pyir::PushNull::create(builder, loc, pyType).getResult());
 }
 
 
 void loadFastBorrowCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                            const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const std::string* name = std::get_if<std::string>(&instr.argval);
     if (!name)
         throw PyCompileError("LOAD_FAST_BORROW must have a string argval", loc);
-    meta.stack.push_back(builder.create<pyir::LoadFast>(loc, pyType, *name).getResult());
+    meta.stack.push_back(pyir::LoadFast::create(builder, loc, pyType, *name).getResult());
 }
 
 
 void loadNameCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                      const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const std::string* name = std::get_if<std::string>(&instr.argval);
     if (!name)
         throw PyCompileError("LOAD_NAME must have a string argval", loc);
-    meta.stack.push_back(builder.create<pyir::LoadName>(loc, pyType, *name).getResult());
+    meta.stack.push_back(pyir::LoadName::create(builder, loc, pyType, *name).getResult());
 }
 
 
@@ -84,19 +84,19 @@ void storeNameCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, const
     const std::string* name = std::get_if<std::string>(&instr.argval);
     if (!name)
         throw PyCompileError("STORE_NAME must have a string argval", loc);
-    mlir::Value val = meta.stack.back();
+    const mlir::Value val = meta.stack.back();
     meta.stack.pop_back();
-    builder.create<pyir::StoreName>(loc, *name, val);
+    pyir::StoreName::create(builder, loc, *name, val);
 }
 
 
 void loadFastCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                      const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const std::string* name = std::get_if<std::string>(&instr.argval);
     if (!name)
         throw PyCompileError("LOAD_FAST must have a string argval", loc);
-    meta.stack.push_back(builder.create<pyir::LoadFast>(loc, pyType, *name).getResult());
+    meta.stack.push_back(pyir::LoadFast::create(builder, loc, pyType, *name).getResult());
 }
 
 
@@ -105,20 +105,20 @@ void storeFastCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, const
     const std::string* name = std::get_if<std::string>(&instr.argval);
     if (!name)
         throw PyCompileError("STORE_FAST must have a string argval", loc);
-    mlir::Value val = meta.stack.back();
+    const mlir::Value val = meta.stack.back();
     meta.stack.pop_back();
-    builder.create<pyir::StoreFast>(loc, *name, val);
+    pyir::StoreFast::create(builder, loc, *name, val);
 }
 
 
 void loadDerefCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                       const ByteCodeInstruction& instr, const CodeInfo& codeInfo, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const int64_t* idx = std::get_if<int64_t>(&instr.argval);
     if (!idx)
         throw PyCompileError("LOAD_DEREF must have an int argval", loc);
     const std::string name = resolveDeref(codeInfo, *idx);
-    meta.stack.push_back(builder.create<pyir::LoadDeref>(loc, pyType, name).getResult());
+    meta.stack.push_back(pyir::LoadDeref::create(builder, loc, pyType, name).getResult());
 }
 
 
@@ -128,9 +128,9 @@ void storeDerefCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, cons
     if (!idx)
         throw PyCompileError("STORE_DEREF must have an int argval", loc);
     const std::string name = resolveDeref(codeInfo, *idx);
-    mlir::Value val = meta.stack.back();
+    const mlir::Value val = meta.stack.back();
     meta.stack.pop_back();
-    builder.create<pyir::StoreDeref>(loc, name, val);
+    pyir::StoreDeref::create(builder, loc, name, val);
 }
 
 
@@ -157,12 +157,12 @@ mlir::ArrayAttr getArrayAttr(mlir::OpBuilder& builder, const std::vector<Primiti
 
 void loadConstCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                       const mlir::func::FuncOp& fn, const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     if (std::holds_alternative<ArgvalNone>(instr.argval)) {
         // None is a valid return value inside functions
         if (meta.isFunction) {
-            mlir::Attribute attr = pyir::NoneAttr::get(&ctx);
-            meta.stack.push_back(builder.create<pyir::LoadConst>(loc, pyType, attr).getResult());
+            const mlir::Attribute attr = pyir::NoneAttr::get(&ctx);
+            meta.stack.push_back(pyir::LoadConst::create(builder, loc, pyType, attr).getResult());
         }
         return;
     }
@@ -180,7 +180,7 @@ void loadConstCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const ml
         builder.setInsertionPointToEnd(parentModule.getBody());
         buildMLIRModule(builder, ctx, nested, fnName);
 
-        const mlir::Value sentinel = builder.create<pyir::PushNull>(loc, pyType).getResult();
+        const mlir::Value sentinel = pyir::PushNull::create(builder, loc, pyType).getResult();
         meta.pendingFunctions[static_cast<mlir::Value*>(sentinel.getAsOpaquePointer())] = fnName;
         meta.stack.push_back(sentinel);
         return;
@@ -201,53 +201,53 @@ void loadConstCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const ml
     else
         throw PyCompileError("LOAD_CONST unknown argval type " + instr.argrepr, loc);
 
-    meta.stack.push_back(builder.create<pyir::LoadConst>(loc, pyType, attr).getResult());
+    meta.stack.push_back(pyir::LoadConst::create(builder, loc, pyType, attr).getResult());
 }
 
 
 void loadAttrCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                      const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const std::string* name = std::get_if<std::string>(&instr.argval);
     if (!name)
         throw PyCompileError("LOAD_ATTR must have a string argval", loc);
-    mlir::Value obj = meta.stack.back();
+    const mlir::Value obj = meta.stack.back();
     meta.stack.pop_back();
-    meta.stack.push_back(builder.create<pyir::LoadAttr>(loc, pyType, obj, *name).getResult());
-    meta.stack.push_back(builder.create<pyir::PushNull>(loc, pyType).getResult());
+    meta.stack.push_back(pyir::LoadAttr::create(builder, loc, pyType, obj, *name).getResult());
+    meta.stack.push_back(pyir::PushNull::create(builder, loc, pyType).getResult());
 }
 
 
 void storeSubscrCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, ConversionMeta& meta) {
-    mlir::Value idx = meta.stack.back();
+    const mlir::Value idx = meta.stack.back();
     meta.stack.pop_back();
-    mlir::Value collection = meta.stack.back();
+    const mlir::Value collection = meta.stack.back();
     meta.stack.pop_back();
-    mlir::Value value = meta.stack.back();
+    const mlir::Value value = meta.stack.back();
     meta.stack.pop_back();
-    builder.create<pyir::StoreSubscr>(loc, collection, idx, value);
+    pyir::StoreSubscr::create(builder, loc, collection, idx, value);
 }
 
 
-void storeFastLoadFastCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
-                              const ByteCodeInstruction& instr, ConversionMeta& meta) {
+void storeFastLoadFastCodegen(mlir::OpBuilder& builder, const mlir::Location& loc, const ByteCodeInstruction& instr,
+                              ConversionMeta& meta) {
     const std::vector<PrimitiveArgvals>* arg = std::get_if<std::vector<PrimitiveArgvals>>(&instr.argval);
     if (!arg)
         throw PyCompileError("STORE_FAST_LOAD_FAST must have an tuplestr argval", loc);
     const std::string storeName = std::get<std::string>(arg->at(0));
     const std::string loadName = std::get<std::string>(arg->at(1));
-    mlir::Value val = meta.stack.back();
+    const mlir::Value val = meta.stack.back();
     meta.stack.pop_back();
-    builder.create<pyir::StoreFast>(loc, storeName, val);
+    pyir::StoreFast::create(builder, loc, storeName, val);
     meta.stack.push_back(val);
 }
 
 
 void loadFastAndClearCodegen(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const mlir::Location& loc,
                              const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const std::string* name = std::get_if<std::string>(&instr.argval);
     if (!name)
         throw PyCompileError("LOAD_FAST_AND_CLEAR must have a string argval", loc);
-    meta.stack.push_back(builder.create<pyir::LoadFastAndClear>(loc, pyType, *name).getResult());
+    meta.stack.push_back(pyir::LoadFastAndClear::create(builder, loc, pyType, *name).getResult());
 }

--- a/src/conversion/pyir_codegen.cpp
+++ b/src/conversion/pyir_codegen.cpp
@@ -42,7 +42,7 @@ mlir::Location getInstructionLocation(mlir::MLIRContext& ctx, const ByteCodeInst
  */
 void buildMLIRInstruction(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const ByteCodeModule& module,
                           mlir::func::FuncOp& fn, const ByteCodeInstruction& instr, ConversionMeta& meta) {
-    pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
+    const pyir::ByteCodeObjectType pyType = pyir::ByteCodeObjectType::get(&ctx);
     const mlir::Location loc = getInstructionLocation(ctx, instr, module.filename);
 
     switch (instr.opcode) {
@@ -135,13 +135,13 @@ void buildMLIRInstruction(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, cons
         case PythonOpcode::STORE_SUBSCR:
             return storeSubscrCodegen(builder, loc, meta);
         case PythonOpcode::STORE_FAST_LOAD_FAST:
-            return storeFastLoadFastCodegen(builder, ctx, loc, instr, meta);
+            return storeFastLoadFastCodegen(builder, loc, instr, meta);
         case PythonOpcode::LOAD_FAST_AND_CLEAR:
             return loadFastAndClearCodegen(builder, ctx, loc, instr, meta);
         // ---- Misc. Ops ----
         case PythonOpcode::PUSH_NULL:
             // Push a null sentinel onto the stack for the call convention.
-            return meta.stack.push_back(builder.create<pyir::PushNull>(loc, pyType).getResult());
+            return meta.stack.push_back(pyir::PushNull::create(builder, loc, pyType).getResult());
         case PythonOpcode::POP_TOP:
             // Discard top of stack, if the value is unused MLIR's DCE will clean up the producing op if it's Pure.
             return meta.stack.pop_back();
@@ -184,7 +184,7 @@ void switchToOffsetBlock(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const
             for (mlir::Value v : branchArgs)
                 targetBlock->addArgument(v.getType(), loc);
         // Add the block at the offset to the MLIR code
-        builder.create<mlir::cf::BranchOp>(loc, targetBlock, mlir::ValueRange{branchArgs});
+        mlir::cf::BranchOp::create(builder, loc, targetBlock, mlir::ValueRange{branchArgs});
     }
 
     builder.setInsertionPointToStart(targetBlock);
@@ -221,7 +221,7 @@ void buildMLIRModule(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const Byt
         fnType = builder.getFunctionType({}, {});
 
     mlir::func::FuncOp fn =
-            builder.create<mlir::func::FuncOp>(mlir::UnknownLoc::get(&ctx), llvm::StringRef(moduleName), fnType);
+            mlir::func::FuncOp::create(builder, mlir::UnknownLoc::get(&ctx), llvm::StringRef(moduleName), fnType);
 
     mlir::Block* block = fn.addEntryBlock();
     builder.setInsertionPointToStart(block);
@@ -232,19 +232,19 @@ void buildMLIRModule(mlir::OpBuilder& builder, mlir::MLIRContext& ctx, const Byt
 
     // For functions, emit push_scope + arg unpacking preamble using block arguments
     if (meta.isFunction) {
-        builder.create<pyir::PushScope>(preambleLoc);
+        pyir::PushScope::create(builder, preambleLoc);
 
-        mlir::Value argsPtr = block->getArgument(0); // args_ptr (!pyir.object, i.e. Value**)
-
+        const mlir::Value argsPtr = block->getArgument(0); // args_ptr (!pyir.object, i.e. Value**)
         for (size_t i = 0; i < static_cast<size_t>(module.info.argcount); i++) {
-            mlir::IntegerAttr idxAttr = builder.getI64IntegerAttr(static_cast<int64_t>(i));
-            mlir::Value argVal = builder.create<pyir::LoadArg>(preambleLoc, pyType, argsPtr, idxAttr).getResult();
-            builder.create<pyir::StoreFast>(preambleLoc, module.info.varnames[i], argVal);
+            const mlir::IntegerAttr idxAttr = builder.getI64IntegerAttr(static_cast<int64_t>(i));
+            const mlir::Value argVal =
+                    pyir::LoadArg::create(builder, preambleLoc, pyType, argsPtr, idxAttr).getResult();
+            pyir::StoreFast::create(builder, preambleLoc, module.info.varnames[i], argVal);
         }
     }
     // For modules, setup dunder variables and state
     else
-        builder.create<pyir::InitModule>(preambleLoc, module.filename, module.moduleName);
+        pyir::InitModule::create(builder, preambleLoc, module.filename, module.moduleName);
 
     // Exception table handler targets also get blocks
     for (const ExceptionTableEntry& e : module.info.exceptionTable)

--- a/src/lowering/builder_lowering.cpp
+++ b/src/lowering/builder_lowering.cpp
@@ -15,28 +15,28 @@ mlir::LogicalResult buildArrayType(mlir::MLIRContext* ctx, mlir::Operation* op,
     const int64_t count = static_cast<int64_t>(operands.size());
 
     // Allocate a stack array of PyObj* to hold all parts: PyObj*[count]
-    mlir::LLVM::LLVMArrayType arrType = mlir::LLVM::LLVMArrayType::get(ptrType(ctx), count);
+    const mlir::LLVM::LLVMArrayType arrType = mlir::LLVM::LLVMArrayType::get(ptrType(ctx), count);
     mlir::LLVM::ConstantOp allocSize =
-            rewriter.create<mlir::LLVM::ConstantOp>(loc, i64Type(ctx), rewriter.getI64IntegerAttr(1));
-    mlir::LLVM::AllocaOp alloca = rewriter.create<mlir::LLVM::AllocaOp>(loc, ptrType(ctx), arrType, allocSize);
+            mlir::LLVM::ConstantOp::create(rewriter, loc, i64Type(ctx), rewriter.getI64IntegerAttr(1));
+    mlir::LLVM::AllocaOp alloca = mlir::LLVM::AllocaOp::create(rewriter, loc, ptrType(ctx), arrType, allocSize);
 
     // Store each part into the array in order
     for (int64_t i = 0; i < count; i++) {
         // Compute pointer to parts[i] via GEP (get element pointer)
         mlir::LLVM::ConstantOp idx =
-                rewriter.create<mlir::LLVM::ConstantOp>(loc, i64Type(ctx), rewriter.getI64IntegerAttr(i));
+                mlir::LLVM::ConstantOp::create(rewriter, loc, i64Type(ctx), rewriter.getI64IntegerAttr(i));
 
         mlir::LLVM::GEPOp gep =
-                rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType(ctx), ptrType(ctx), alloca, mlir::ValueRange{idx});
+                mlir::LLVM::GEPOp::create(rewriter, loc, ptrType(ctx), ptrType(ctx), alloca, mlir::ValueRange{idx});
 
         // Store the i-th operand (a PyObj*) into parts[i]
-        rewriter.create<mlir::LLVM::StoreOp>(loc, operands[i], gep);
+        mlir::LLVM::StoreOp::create(rewriter, loc, operands[i], gep);
     }
 
     // Pass the array pointer and count to the called function
     mlir::LLVM::ConstantOp countVal =
-            rewriter.create<mlir::LLVM::ConstantOp>(loc, i64Type(ctx), rewriter.getI64IntegerAttr(count));
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{alloca, countVal});
+            mlir::LLVM::ConstantOp::create(rewriter, loc, i64Type(ctx), rewriter.getI64IntegerAttr(count));
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{alloca, countVal});
     rewriter.replaceOp(op, call.getResult());
     return mlir::success();
 }
@@ -80,10 +80,10 @@ mlir::LogicalResult ListExtendLowering::matchAndRewrite(mlir::Operation* op, con
     // declare: extern void pyir_listExtend(PyObj* list, PyObj* items)
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(mlir::LLVM::LLVMVoidType::get(ctx), {ptrType(ctx), ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_listExtend", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_listExtend", fnType);
 
     // operands[0] = list, operands[1] = items
-    rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{operands[0], operands[1]});
+    mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{operands[0], operands[1]});
     rewriter.eraseOp(op);
     return mlir::success();
 }
@@ -98,10 +98,10 @@ mlir::LogicalResult ListAppendLowering::matchAndRewrite(mlir::Operation* op, con
     // declare: extern void pyir_listAppend(PyObj* list, PyObj* item)
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(mlir::LLVM::LLVMVoidType::get(ctx), {ptrType(ctx), ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_listAppend", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_listAppend", fnType);
 
     // operands[0] = list, operands[1] = item
-    rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{operands[0], operands[1]});
+    mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{operands[0], operands[1]});
     rewriter.eraseOp(op);
     return mlir::success();
 }
@@ -130,10 +130,10 @@ mlir::LogicalResult SetUpdateLowering::matchAndRewrite(mlir::Operation* op, cons
     // declare: extern void pyir_setUpdate(PyObj* set, PyObj* items)
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(mlir::LLVM::LLVMVoidType::get(ctx), {ptrType(ctx), ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_setUpdate", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_setUpdate", fnType);
 
     // operands[0] = set, operands[1] = items
-    rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{operands[0], operands[1]});
+    mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{operands[0], operands[1]});
     rewriter.eraseOp(op);
     return mlir::success();
 }
@@ -148,10 +148,10 @@ mlir::LogicalResult SetAddLowering::matchAndRewrite(mlir::Operation* op, const m
     // declare: extern void pyir_setAdd(PyObj* set, PyObj* item)
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(mlir::LLVM::LLVMVoidType::get(ctx), {ptrType(ctx), ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_setAdd", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_setAdd", fnType);
 
     // operands[0] = set, operands[1] = item
-    rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{operands[0], operands[1]});
+    mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{operands[0], operands[1]});
     rewriter.eraseOp(op);
     return mlir::success();
 }
@@ -180,10 +180,10 @@ mlir::LogicalResult MapAddLowering::matchAndRewrite(mlir::Operation* op, const m
     // declare: extern void pyir_mapAdd(PyObj* dict, PyObj* key, PyObj* value)
     const mlir::LLVM::LLVMFunctionType fnType = mlir::LLVM::LLVMFunctionType::get(
             mlir::LLVM::LLVMVoidType::get(ctx), {ptrType(ctx), ptrType(ctx), ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_mapAdd", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_mapAdd", fnType);
 
     // operands[0] = map, operands[1] = key, operands[2] = value
-    rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{operands[0], operands[1], operands[2]});
+    mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{operands[0], operands[1], operands[2]});
     rewriter.eraseOp(op);
     return mlir::success();
 }

--- a/src/lowering/control_flow_lowering.cpp
+++ b/src/lowering/control_flow_lowering.cpp
@@ -20,9 +20,9 @@ mlir::LogicalResult PopTopLowering::matchAndRewrite(mlir::Operation* op, const m
 
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(mlir::LLVM::LLVMVoidType::get(ctx), {ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_decref", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_decref", fnType);
 
-    rewriter.create<mlir::LLVM::CallOp>(loc, fn, operands[0]);
+    mlir::LLVM::CallOp::create(rewriter, loc, fn, operands[0]);
     rewriter.eraseOp(op);
     return mlir::success();
 }
@@ -42,15 +42,15 @@ mlir::LogicalResult ForIterLowering::matchAndRewrite(mlir::Operation* op, const 
 
     // declare: extern PyObj* pyir_forIter(PyObj* iterator)
     const mlir::LLVM::LLVMFunctionType fnType = mlir::LLVM::LLVMFunctionType::get(ptrType(ctx), {ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, getModule(op), "pyir_forIter", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, getModule(op), "pyir_forIter", fnType);
 
     // Advance the iterator, returns nullptr if exhausted
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{operands[0]});
-    mlir::Value next = call.getResult();
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{operands[0]});
+    const mlir::Value next = call.getResult();
 
     // Check if result is null: icmp ne %next, null
-    mlir::Value null = rewriter.create<mlir::LLVM::ZeroOp>(loc, ptrType(ctx));
-    mlir::Value cond = rewriter.create<mlir::LLVM::ICmpOp>(loc, mlir::LLVM::ICmpPredicate::ne, next, null);
+    const mlir::Value null = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrType(ctx));
+    mlir::Value cond = mlir::LLVM::ICmpOp::create(rewriter, loc, mlir::LLVM::ICmpPredicate::ne, next, null);
 
     // Branch to body with next value, or to exit if exhausted
     mlir::Block* bodyBlock = forIter.getBody();
@@ -84,9 +84,9 @@ mlir::LogicalResult PopIterLowering::matchAndRewrite(mlir::Operation* op, mlir::
     // declare: extern void pyir_popIter()
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(mlir::LLVM::LLVMVoidType::get(ctx), {});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_popIter", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_popIter", fnType);
 
-    rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{});
+    mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{});
     rewriter.eraseOp(op);
     return mlir::success();
 }

--- a/src/lowering/function_lowering.cpp
+++ b/src/lowering/function_lowering.cpp
@@ -19,33 +19,33 @@ mlir::LogicalResult CallLowering::matchAndRewrite(mlir::Operation* op, const mli
     // declare: extern PyObj* pyir_call(PyObj* callee, Value** args, int64_t argc)
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(ptrType(ctx), {ptrType(ctx), ptrType(ctx), i64Type(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_call", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_call", fnType);
 
     // Allocate args array on the stack: PyObj*[argc]
     mlir::Value argsPtr;
     if (argc > 0) {
-        mlir::LLVM::LLVMArrayType arrType = mlir::LLVM::LLVMArrayType::get(ptrType(ctx), argc);
-        mlir::LLVM::AllocaOp alloca = rewriter.create<mlir::LLVM::AllocaOp>(
-                loc, ptrType(ctx), arrType,
-                rewriter.create<mlir::LLVM::ConstantOp>(loc, i64Type(ctx), rewriter.getI64IntegerAttr(1)));
+        const mlir::LLVM::LLVMArrayType arrType = mlir::LLVM::LLVMArrayType::get(ptrType(ctx), argc);
+        mlir::LLVM::AllocaOp alloca = mlir::LLVM::AllocaOp::create(
+                rewriter, loc, ptrType(ctx), arrType,
+                mlir::LLVM::ConstantOp::create(rewriter, loc, i64Type(ctx), rewriter.getI64IntegerAttr(1)));
 
         // Store each arg into the array
         for (int64_t i = 0; i < argc; i++) {
             mlir::LLVM::ConstantOp idx =
-                    rewriter.create<mlir::LLVM::ConstantOp>(loc, i64Type(ctx), rewriter.getI64IntegerAttr(i));
+                    mlir::LLVM::ConstantOp::create(rewriter, loc, i64Type(ctx), rewriter.getI64IntegerAttr(i));
             mlir::LLVM::GEPOp gep =
-                    rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType(ctx), ptrType(ctx), alloca, mlir::ValueRange{idx});
-            rewriter.create<mlir::LLVM::StoreOp>(loc, args[i], gep);
+                    mlir::LLVM::GEPOp::create(rewriter, loc, ptrType(ctx), ptrType(ctx), alloca, mlir::ValueRange{idx});
+            mlir::LLVM::StoreOp::create(rewriter, loc, args[i], gep);
         }
         argsPtr = alloca;
     } else
         // nullptr for empty args
-        argsPtr = rewriter.create<mlir::LLVM::ZeroOp>(loc, ptrType(ctx));
+        argsPtr = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrType(ctx));
 
     mlir::LLVM::ConstantOp argcVal =
-            rewriter.create<mlir::LLVM::ConstantOp>(loc, i64Type(ctx), rewriter.getI64IntegerAttr(argc));
+            mlir::LLVM::ConstantOp::create(rewriter, loc, i64Type(ctx), rewriter.getI64IntegerAttr(argc));
 
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{callee, argsPtr, argcVal});
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{callee, argsPtr, argcVal});
 
     rewriter.replaceOp(op, call.getResult());
     return mlir::success();
@@ -61,9 +61,9 @@ mlir::LogicalResult PushScopeLowering::matchAndRewrite(mlir::Operation* op, mlir
     // declare: extern void pyir_pushScope()
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(mlir::LLVM::LLVMVoidType::get(ctx), {});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_pushScope", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_pushScope", fnType);
 
-    rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{});
+    mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{});
     rewriter.eraseOp(op);
     return mlir::success();
 }
@@ -78,9 +78,9 @@ mlir::LogicalResult PopScopeLowering::matchAndRewrite(mlir::Operation* op, mlir:
     // declare: extern void pyir_popScope()
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(mlir::LLVM::LLVMVoidType::get(ctx), {});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_popScope", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_popScope", fnType);
 
-    rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{});
+    mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{});
     rewriter.eraseOp(op);
     return mlir::success();
 }
@@ -98,14 +98,14 @@ mlir::LogicalResult MakeFunctionLowering::matchAndRewrite(mlir::Operation* op, m
     // declare: extern PyObj* pyir_makeFunction(char* display_name, void* fn_ptr)
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(ptrType(ctx), {ptrType(ctx), ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp runtimeFn = getOrInsertRuntimeFn(rewriter, module, "pyir_makeFunction", fnType);
+    const mlir::LLVM::LLVMFuncOp runtimeFn = getOrInsertRuntimeFn(rewriter, module, "pyir_makeFunction", fnType);
 
     // Get function pointer from symbol table
-    const mlir::Value fnPtr = rewriter.create<mlir::LLVM::AddressOfOp>(loc, ptrType(ctx), fnName);
+    const mlir::Value fnPtr = mlir::LLVM::AddressOfOp::create(rewriter, loc, ptrType(ctx), fnName);
     const std::string globalName = "__pyir_str_fn_" + makeFunc.getFnName().str();
     const mlir::Value namePtr = getOrInsertStringConstant(rewriter, module, loc, globalName, makeFunc.getFnName());
 
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, runtimeFn, mlir::ValueRange{namePtr, fnPtr});
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, runtimeFn, mlir::ValueRange{namePtr, fnPtr});
 
     rewriter.replaceOp(op, call.getResult());
     return mlir::success();

--- a/src/lowering/llvm_export.cpp
+++ b/src/lowering/llvm_export.cpp
@@ -67,7 +67,7 @@ static std::unique_ptr<llvm::TargetMachine> createTargetMachine(const LLVMExport
             options.cpu.empty() || options.cpu == "native" ? llvm::sys::getHostCPUName().str() : options.cpu;
 
     std::string err;
-    const llvm::Target* target = llvm::TargetRegistry::lookupTarget(triple.str(), err);
+    const llvm::Target* target = llvm::TargetRegistry::lookupTarget(triple, err);
     if (!target)
         throw std::runtime_error("failed to lookup LLVM target: " + err);
 

--- a/src/lowering/logical_lowering.cpp
+++ b/src/lowering/logical_lowering.cpp
@@ -14,13 +14,13 @@ mlir::LogicalResult IsTruthyLowering::matchAndRewrite(mlir::Operation* op, const
     // declare: extern int8_t pyir_isTruthy(PyObj* val)
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(mlir::IntegerType::get(ctx, 8), {ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_isTruthy", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_isTruthy", fnType);
 
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{operands[0]});
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{operands[0]});
 
     // truncate i8 to i1 for cf.cond_br
     const mlir::Value i1val =
-            rewriter.create<mlir::LLVM::TruncOp>(loc, mlir::IntegerType::get(ctx, 1), call.getResult());
+            mlir::LLVM::TruncOp::create(rewriter, loc, mlir::IntegerType::get(ctx, 1), call.getResult());
 
     rewriter.replaceOp(op, i1val);
     return mlir::success();

--- a/src/lowering/memory_lowering.cpp
+++ b/src/lowering/memory_lowering.cpp
@@ -16,13 +16,13 @@ mlir::LogicalResult InitModuleLowering::matchAndRewrite(mlir::Operation* op, mli
     // declare: extern void pyir_initModule(const char* file, const char* name)
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(mlir::LLVM::LLVMVoidType::get(ctx), {ptrType(ctx), ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_initModule", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_initModule", fnType);
 
     const std::string globalFile = "__pyir_str_" + initModule.getFile().str();
     const std::string globalName = "__pyir_str_" + initModule.getName().str();
     const mlir::Value filePtr = getOrInsertStringConstant(rewriter, module, loc, globalFile, initModule.getFile());
     const mlir::Value namePtr = getOrInsertStringConstant(rewriter, module, loc, globalName, initModule.getName());
-    rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{filePtr, namePtr});
+    mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{filePtr, namePtr});
     rewriter.eraseOp(op);
     return mlir::success();
 }
@@ -37,9 +37,9 @@ mlir::LogicalResult DestroyModuleLowering::matchAndRewrite(mlir::Operation* op, 
     // declare: extern void pyir_destroyModule()
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(mlir::LLVM::LLVMVoidType::get(ctx), {});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_destroyModule", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_destroyModule", fnType);
 
-    rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{});
+    mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{});
     rewriter.eraseOp(op);
     return mlir::success();
 }
@@ -54,11 +54,11 @@ mlir::LogicalResult LoadFastLowering::matchAndRewrite(mlir::Operation* op, mlir:
 
     // declare: extern PyObj* pyir_loadFast(const char* name)
     const mlir::LLVM::LLVMFunctionType fnType = mlir::LLVM::LLVMFunctionType::get(ptrType(ctx), {ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadFast", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadFast", fnType);
 
     const std::string globalName = "__pyir_str_" + loadFast.getVarName().str();
     const mlir::Value strPtr = getOrInsertStringConstant(rewriter, module, loc, globalName, loadFast.getVarName());
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{strPtr});
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{strPtr});
     rewriter.replaceOp(op, call.getResult());
     return mlir::success();
 }
@@ -73,12 +73,12 @@ mlir::LogicalResult LoadFastAndClearLowering::matchAndRewrite(mlir::Operation* o
 
     // declare: extern PyObj* pyir_loadFastAndClear(const char* name)
     const mlir::LLVM::LLVMFunctionType fnType = mlir::LLVM::LLVMFunctionType::get(ptrType(ctx), {ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadFastAndClear", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadFastAndClear", fnType);
 
     const std::string globalName = "__pyir_str_" + loadFastAndClear.getVarName().str();
     const mlir::Value strPtr =
             getOrInsertStringConstant(rewriter, module, loc, globalName, loadFastAndClear.getVarName());
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{strPtr});
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{strPtr});
     rewriter.replaceOp(op, call.getResult());
     return mlir::success();
 }
@@ -94,11 +94,11 @@ mlir::LogicalResult StoreFastLowering::matchAndRewrite(mlir::Operation* op, cons
     // declare: extern void pyir_storeFast(const char* name, PyObj* val)
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(mlir::LLVM::LLVMVoidType::get(ctx), {ptrType(ctx), ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_storeFast", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_storeFast", fnType);
 
     const std::string globalName = "__pyir_str_" + storeFast.getVarName().str();
     const mlir::Value strPtr = getOrInsertStringConstant(rewriter, module, loc, globalName, storeFast.getVarName());
-    rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{strPtr, operands[0]});
+    mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{strPtr, operands[0]});
     rewriter.eraseOp(op);
     return mlir::success();
 }
@@ -113,11 +113,11 @@ mlir::LogicalResult LoadNameLowering::matchAndRewrite(mlir::Operation* op, mlir:
 
     // declare: extern PyObj* pyir_loadName(const char* name)
     const mlir::LLVM::LLVMFunctionType fnType = mlir::LLVM::LLVMFunctionType::get(ptrType(ctx), {ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadName", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadName", fnType);
 
     const std::string globalName = "__pyir_str_" + loadName.getVarName().str();
     const mlir::Value strPtr = getOrInsertStringConstant(rewriter, module, loc, globalName, loadName.getVarName());
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{strPtr});
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{strPtr});
     rewriter.replaceOp(op, call.getResult());
     return mlir::success();
 }
@@ -133,11 +133,11 @@ mlir::LogicalResult StoreNameLowering::matchAndRewrite(mlir::Operation* op, cons
     // declare: extern void pyir_storeName(const char* name, PyObj* val)
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(mlir::LLVM::LLVMVoidType::get(ctx), {ptrType(ctx), ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_storeName", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_storeName", fnType);
 
     const std::string globalName = "__pyir_str_" + storeName.getVarName().str();
     const mlir::Value strPtr = getOrInsertStringConstant(rewriter, module, loc, globalName, storeName.getVarName());
-    rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{strPtr, operands[0]});
+    mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{strPtr, operands[0]});
     rewriter.eraseOp(op);
     return mlir::success();
 }
@@ -148,13 +148,13 @@ mlir::Value LoadConstLowering::loadStringConst(mlir::ConversionPatternRewriter& 
                                                const mlir::StringAttr& strAttr) {
     // declare: extern PyObj* pyir_loadConstStr(const char* str)
     const mlir::LLVM::LLVMFunctionType fnType = mlir::LLVM::LLVMFunctionType::get(ptrType(ctx), {ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadConstStr", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadConstStr", fnType);
 
     // create global string constant
     const std::string str = strAttr.getValue().str();
     const std::string gName = "__pyir_const_str_" + std::to_string(std::hash<std::string>{}(str));
     const mlir::Value strPtr = getOrInsertStringConstant(rewriter, module, loc, gName, str);
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{strPtr});
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{strPtr});
     return call.getResult();
 }
 
@@ -164,10 +164,10 @@ mlir::Value LoadConstLowering::loadBoolConst(mlir::ConversionPatternRewriter& re
                                              const mlir::BoolAttr& boolAttr) {
     // declare: extern PyObj* pyir_loadConstBool(int_8 val)
     const mlir::LLVM::LLVMFunctionType fnType = mlir::LLVM::LLVMFunctionType::get(ptrType(ctx), {boolType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadConstBool", fnType);
-    mlir::LLVM::ConstantOp boolVal = rewriter.create<mlir::LLVM::ConstantOp>(
-            loc, boolType(ctx), rewriter.getI8IntegerAttr(boolAttr.getValue() ? 1 : 0));
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{boolVal});
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadConstBool", fnType);
+    mlir::LLVM::ConstantOp boolVal = mlir::LLVM::ConstantOp::create(
+            rewriter, loc, boolType(ctx), rewriter.getI8IntegerAttr(boolAttr.getValue() ? 1 : 0));
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{boolVal});
     return call.getResult();
 }
 
@@ -177,10 +177,10 @@ mlir::Value LoadConstLowering::loadIntConst(mlir::ConversionPatternRewriter& rew
                                             const mlir::IntegerAttr& intAttr) {
     // declare: extern PyObj* pyir_loadConstInt(int64_t val)
     const mlir::LLVM::LLVMFunctionType fnType = mlir::LLVM::LLVMFunctionType::get(ptrType(ctx), {i64Type(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadConstInt", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadConstInt", fnType);
     mlir::LLVM::ConstantOp intVal =
-            rewriter.create<mlir::LLVM::ConstantOp>(loc, i64Type(ctx), rewriter.getI64IntegerAttr(intAttr.getInt()));
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{intVal});
+            mlir::LLVM::ConstantOp::create(rewriter, loc, i64Type(ctx), rewriter.getI64IntegerAttr(intAttr.getInt()));
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{intVal});
     return call.getResult();
 }
 
@@ -190,10 +190,10 @@ mlir::Value LoadConstLowering::loadFloatConst(mlir::ConversionPatternRewriter& r
                                               const mlir::FloatAttr& floatAttr) {
     // declare: extern PyObj* pyir_loadConstFloat(double_t val)
     const mlir::LLVM::LLVMFunctionType fnType = mlir::LLVM::LLVMFunctionType::get(ptrType(ctx), {f64Type(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadConstFloat", fnType);
-    mlir::LLVM::ConstantOp floatVal = rewriter.create<mlir::LLVM::ConstantOp>(
-            loc, f64Type(ctx), rewriter.getF64FloatAttr(floatAttr.getValueAsDouble()));
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{floatVal});
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadConstFloat", fnType);
+    mlir::LLVM::ConstantOp floatVal = mlir::LLVM::ConstantOp::create(
+            rewriter, loc, f64Type(ctx), rewriter.getF64FloatAttr(floatAttr.getValueAsDouble()));
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{floatVal});
     return call.getResult();
 }
 
@@ -202,8 +202,8 @@ mlir::Value LoadConstLowering::loadNoneConst(mlir::ConversionPatternRewriter& re
                                              const mlir::Location& loc, const mlir::ModuleOp& module) {
     // declare: extern PyObj* pyir_loadConstNone()
     const mlir::LLVM::LLVMFunctionType fnType = mlir::LLVM::LLVMFunctionType::get(ptrType(ctx), {});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadConstNone", fnType);
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{});
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadConstNone", fnType);
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{});
     return call.getResult();
 }
 
@@ -214,17 +214,17 @@ mlir::Value LoadConstLowering::loadTupleConst(mlir::ConversionPatternRewriter& r
     // declare: extern PyObj* pyir_loadConstTuple(Value** items, int64_t count)
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(ptrType(ctx), {ptrType(ctx), i64Type(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadConstTuple", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadConstTuple", fnType);
 
     const int64_t count = static_cast<int64_t>(arrAttr.size());
 
     mlir::Value partsPtr;
     if (count > 0) {
         // Allocate stack array of PyObj*[count]
-        mlir::LLVM::LLVMArrayType arrType = mlir::LLVM::LLVMArrayType::get(ptrType(ctx), count);
+        const mlir::LLVM::LLVMArrayType arrType = mlir::LLVM::LLVMArrayType::get(ptrType(ctx), count);
         mlir::LLVM::ConstantOp allocSize =
-                rewriter.create<mlir::LLVM::ConstantOp>(loc, i64Type(ctx), rewriter.getI64IntegerAttr(1));
-        mlir::LLVM::AllocaOp alloca = rewriter.create<mlir::LLVM::AllocaOp>(loc, ptrType(ctx), arrType, allocSize);
+                mlir::LLVM::ConstantOp::create(rewriter, loc, i64Type(ctx), rewriter.getI64IntegerAttr(1));
+        mlir::LLVM::AllocaOp alloca = mlir::LLVM::AllocaOp::create(rewriter, loc, ptrType(ctx), arrType, allocSize);
 
         // Materialize each element as a PyObj* and store into the array
         for (int64_t i = 0; i < count; i++) {
@@ -243,18 +243,18 @@ mlir::Value LoadConstLowering::loadTupleConst(mlir::ConversionPatternRewriter& r
                 throw std::runtime_error("Unsupported element type in tuple");
 
             mlir::LLVM::ConstantOp idx =
-                    rewriter.create<mlir::LLVM::ConstantOp>(loc, i64Type(ctx), rewriter.getI64IntegerAttr(i));
+                    mlir::LLVM::ConstantOp::create(rewriter, loc, i64Type(ctx), rewriter.getI64IntegerAttr(i));
             mlir::LLVM::GEPOp gep =
-                    rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType(ctx), ptrType(ctx), alloca, mlir::ValueRange{idx});
-            rewriter.create<mlir::LLVM::StoreOp>(loc, elemVal, gep);
+                    mlir::LLVM::GEPOp::create(rewriter, loc, ptrType(ctx), ptrType(ctx), alloca, mlir::ValueRange{idx});
+            mlir::LLVM::StoreOp::create(rewriter, loc, elemVal, gep);
         }
         partsPtr = alloca;
     } else
-        partsPtr = rewriter.create<mlir::LLVM::ZeroOp>(loc, ptrType(ctx));
+        partsPtr = mlir::LLVM::ZeroOp::create(rewriter, loc, ptrType(ctx));
 
     mlir::LLVM::ConstantOp countVal =
-            rewriter.create<mlir::LLVM::ConstantOp>(loc, i64Type(ctx), rewriter.getI64IntegerAttr(count));
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{partsPtr, countVal});
+            mlir::LLVM::ConstantOp::create(rewriter, loc, i64Type(ctx), rewriter.getI64IntegerAttr(count));
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{partsPtr, countVal});
     return call.getResult();
 }
 
@@ -297,16 +297,16 @@ mlir::LogicalResult LoadArgLowering::matchAndRewrite(mlir::Operation* op, const 
     const int64_t index = static_cast<int64_t>(loadArg.getIndex());
 
     // operands[0] is the args_ptr (Value** as !llvm.ptr)
-    mlir::Value argsPtr = operands[0];
+    const mlir::Value argsPtr = operands[0];
 
     // GEP into args[index]
     mlir::LLVM::ConstantOp idx =
-            rewriter.create<mlir::LLVM::ConstantOp>(loc, i64Type(ctx), rewriter.getI64IntegerAttr(index));
+            mlir::LLVM::ConstantOp::create(rewriter, loc, i64Type(ctx), rewriter.getI64IntegerAttr(index));
     mlir::LLVM::GEPOp gep =
-            rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType(ctx), ptrType(ctx), argsPtr, mlir::ValueRange{idx});
+            mlir::LLVM::GEPOp::create(rewriter, loc, ptrType(ctx), ptrType(ctx), argsPtr, mlir::ValueRange{idx});
 
     // Load PyObj* from args[index]
-    mlir::LLVM::LoadOp load = rewriter.create<mlir::LLVM::LoadOp>(loc, ptrType(ctx), gep);
+    mlir::LLVM::LoadOp load = mlir::LLVM::LoadOp::create(rewriter, loc, ptrType(ctx), gep);
 
     rewriter.replaceOp(op, load.getResult());
     return mlir::success();
@@ -323,13 +323,13 @@ mlir::LogicalResult LoadAttrLowering::matchAndRewrite(mlir::Operation* op, const
     // declare: extern PyObj* pyir_loadAttr(PyObj* obj, const char* name)
     const mlir::LLVM::LLVMFunctionType fnType =
             mlir::LLVM::LLVMFunctionType::get(ptrType(ctx), {ptrType(ctx), ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadAttr", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_loadAttr", fnType);
 
     const std::string globalName = "__pyir_str_" + loadAttr.getAttrName().str();
     const mlir::Value namePtr = getOrInsertStringConstant(rewriter, module, loc, globalName, loadAttr.getAttrName());
 
     // operands[0] is the object
-    mlir::LLVM::CallOp call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{operands[0], namePtr});
+    mlir::LLVM::CallOp call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{operands[0], namePtr});
 
     rewriter.replaceOp(op, call.getResult());
     return mlir::success();
@@ -346,9 +346,9 @@ mlir::LogicalResult StoreSubscrLowering::matchAndRewrite(mlir::Operation* op,
     // declare: extern void pyir_storeSubscr(PyObj* container, PyObj* idx, PyObj* value)
     const mlir::LLVM::LLVMFunctionType fnType = mlir::LLVM::LLVMFunctionType::get(
             mlir::LLVM::LLVMVoidType::get(ctx), {ptrType(ctx), ptrType(ctx), ptrType(ctx)});
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_storeSubscr", fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, "pyir_storeSubscr", fnType);
 
-    rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{operands[0], operands[1], operands[2]});
+    mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{operands[0], operands[1], operands[2]});
     rewriter.eraseOp(op);
     return mlir::success();
 }

--- a/src/lowering/pyir_conversion_utils.cpp
+++ b/src/lowering/pyir_conversion_utils.cpp
@@ -22,30 +22,31 @@ mlir::Type f64Type(mlir::MLIRContext* ctx) { return mlir::Float64Type::get(ctx);
 
 
 mlir::LLVM::LLVMFuncOp getOrInsertRuntimeFn(mlir::PatternRewriter& rewriter, mlir::ModuleOp module,
-                                            llvm::StringRef name, mlir::LLVM::LLVMFunctionType fnType) {
+                                            const llvm::StringRef name, const mlir::LLVM::LLVMFunctionType fnType) {
     if (const mlir::LLVM::LLVMFuncOp fn = module.lookupSymbol<mlir::LLVM::LLVMFuncOp>(name))
         return fn;
 
     mlir::PatternRewriter::InsertionGuard guard(rewriter);
     rewriter.setInsertionPointToStart(module.getBody());
-    return rewriter.create<mlir::LLVM::LLVMFuncOp>(rewriter.getUnknownLoc(), name, fnType,
-                                                   mlir::LLVM::Linkage::External);
+    return mlir::LLVM::LLVMFuncOp::create(rewriter, rewriter.getUnknownLoc(), name, fnType,
+                                          mlir::LLVM::Linkage::External);
 }
 
 
 mlir::Value getOrInsertStringConstant(mlir::ConversionPatternRewriter& rewriter, mlir::ModuleOp module,
-                                      const mlir::Location loc, llvm::StringRef name, const llvm::StringRef str) {
+                                      const mlir::Location loc, const llvm::StringRef name, const llvm::StringRef str) {
     auto* ctx = module.getContext();
 
     if (!module.lookupSymbol(name)) {
         mlir::PatternRewriter::InsertionGuard guard(rewriter);
         rewriter.setInsertionPointToStart(module.getBody());
-        auto strType = mlir::LLVM::LLVMArrayType::get(i8Type(ctx), str.size() + 1);
-        rewriter.create<mlir::LLVM::GlobalOp>(loc, strType, /*isConstant=*/true, mlir::LLVM::Linkage::Private, name,
-                                              rewriter.getStringAttr(str.str() + '\0'));
+        const auto strType = mlir::LLVM::LLVMArrayType::get(i8Type(ctx), str.size() + 1);
+        mlir::LLVM::GlobalOp::create(rewriter, loc, strType, /*isConstant=*/true, mlir::LLVM::Linkage::Private, name,
+                                     rewriter.getStringAttr(str.str() + '\0'));
     }
 
-    return rewriter.create<mlir::LLVM::AddressOfOp>(loc, ptrType(ctx), name);
+    const mlir::Value result = mlir::LLVM::AddressOfOp::create(rewriter, loc, ptrType(ctx), name);
+    return result;
 }
 
 
@@ -66,14 +67,14 @@ mlir::LogicalResult PyIROpConversion::linkOpToRuntimeFunc(const std::string& fun
     else
         throw std::runtime_error("Unsupported number of args in runtime function link");
 
-    mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, func, fnType);
+    const mlir::LLVM::LLVMFuncOp fn = getOrInsertRuntimeFn(rewriter, module, func, fnType);
 
     // Choose correct call operation based on arguments
     mlir::LLVM::CallOp call;
     if (argc == 1)
-        call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{operands[0]});
+        call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{operands[0]});
     else
-        call = rewriter.create<mlir::LLVM::CallOp>(loc, fn, mlir::ValueRange{operands[0], operands[1]});
+        call = mlir::LLVM::CallOp::create(rewriter, loc, fn, mlir::ValueRange{operands[0], operands[1]});
 
     rewriter.replaceOp(op, call.getResult());
     return mlir::success();

--- a/src/lowering/pyir_lowering.cpp
+++ b/src/lowering/pyir_lowering.cpp
@@ -7,7 +7,6 @@
 #include <filesystem>
 
 #include "pyir/pyir_attrs.h"
-#include "pyir/pyir_ops.h"
 #include "pyir/pyir_types.h"
 
 #include <mlir/Conversion/ArithToLLVM/ArithToLLVM.h>

--- a/src/pyir/pyir_attrs.cpp
+++ b/src/pyir/pyir_attrs.cpp
@@ -5,5 +5,6 @@
 #include "pyir/pyir_attrs.h"
 
 #define GET_ATTRDEF_CLASSES
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "pyir_attrs.cpp.inc"
 #undef GET_ATTRDEF_CLASSES

--- a/src/pyir/pyir_types.cpp
+++ b/src/pyir/pyir_types.cpp
@@ -5,5 +5,6 @@
 #include "pyir/pyir_types.h"
 
 #define GET_TYPEDEF_CLASSES
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "pyir_types.cpp.inc"
 #undef GET_TYPEDEF_CLASSES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,12 @@ target_include_directories(pycompile-tests SYSTEM PRIVATE
         ${MLIR_INCLUDE_DIRS}
         ${LLVM_INCLUDE_DIRS}
 )
+set_target_properties(pycompile-tests PROPERTIES
+        COMPILE_WARNING_AS_ERROR ON
+)
+target_compile_options(pycompile-tests PRIVATE
+        $<$<CXX_COMPILER_ID:Clang>:-Wno-c2y-extensions>
+)
 
 include(CTest)
 include(Catch)

--- a/test/execution/execution_test_utils.h
+++ b/test/execution/execution_test_utils.h
@@ -32,7 +32,11 @@
 static std::string captureStdout(const std::function<void()>& fn) {
     // Redirect stdout to a pipe
     int pipeFileDescriptor[2];
-    pipe(pipeFileDescriptor);
+    if (pipe(pipeFileDescriptor) == -1) {
+        perror("pipe");
+        exit(EXIT_FAILURE);
+    }
+
     const int savedStdout = dup(STDOUT_FILENO);
     dup2(pipeFileDescriptor[1], STDOUT_FILENO);
     close(pipeFileDescriptor[1]);
@@ -71,9 +75,15 @@ static std::string captureStdout(const std::function<void()>& fn) {
  */
 static void withStdinInput(const std::function<void()>& fn, const std::string& input) {
     int pipeFileDescriptor[2];
-    pipe(pipeFileDescriptor);
+    if (pipe(pipeFileDescriptor) == -1) {
+        perror("pipe");
+        exit(EXIT_FAILURE);
+    }
 
-    write(pipeFileDescriptor[1], input.c_str(), input.size());
+    if (write(pipeFileDescriptor[1], input.c_str(), input.size()) == -1) {
+        perror("write failed");
+        exit(EXIT_FAILURE);
+    }
     close(pipeFileDescriptor[1]);
 
     const int savedStdin = dup(STDIN_FILENO);


### PR DESCRIPTION
# Summary

This PR fixes warnings related to the upgrade from LLVM 21 to LLVM 22 in addition to other various MLIR warnings.

## Related Issue(s)

* #93

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Test or fixture update
* [x] Reorganization or Refactor
